### PR TITLE
Reduce number of CI builds chefspec results in 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,8 @@
 rvm:
   - 1.8.7
   - 1.9.2
-  - rbx
   - rbx-2.0
 env:
-  - CHEF_VERSION=0.9.12
-  - CHEF_VERSION=0.9.14
-  - CHEF_VERSION=0.9.16
   - CHEF_VERSION=0.9.18
-  - CHEF_VERSION=0.10
   - CHEF_VERSION=0.10.2
   - CHEF_VERSION=0.10.4.rc.5


### PR DESCRIPTION
Would it be possible to only test against the latest 0.9.x and 0.10.x (including RCs, that's a good idea)?

chefspec run takes on average 12 minutes. Right now it results in over 20 builds per push. Simple math suggests that is 4 hours of run time. Even though we now have 10 workers on travis-ci.org, it is a bit difficult to justify testing against 0.9.12 vs 0.9.18 if it leads to run times like this.

Thank you.
