### PR TITLE
Set automatic attribute "languages"

### DIFF
--- a/lib/chefspec/chef_runner.rb
+++ b/lib/chefspec/chef_runner.rb
@@ -143,7 +143,7 @@ module ChefSpec
     # @param [Ohai::System] ohai The ohai instance to set fake attributes on
     def fake_ohai(ohai)
       {:os => 'chefspec', :os_version => ChefSpec::VERSION, :fqdn => 'chefspec.local', :domain => 'local',
-       :ipaddress => '127.0.0.1', :hostname => 'chefspec',
+       :ipaddress => '127.0.0.1', :hostname => 'chefspec', :languages => Mash.new({"ruby" => "/usr/somewhere"}),
        :kernel => Mash.new({:machine => 'i386'})}.each_pair do |attribute,value|
         ohai[attribute] = value
       end

--- a/spec/chefspec/chef_runner_spec.rb
+++ b/spec/chefspec/chef_runner_spec.rb
@@ -46,6 +46,7 @@ module ChefSpec
       context "default ohai attributes" do
         let(:node){ChefSpec::ChefRunner.new.node}
         specify{node.os.should == 'chefspec'}
+        specify{node.languages['ruby'].should == "/usr/somewhere"}
         specify{node.os_version.should == ChefSpec::VERSION}
         specify{node.fqdn.should == 'chefspec.local'}
         specify{node.domain.should == 'local'}


### PR DESCRIPTION
- Some cookbooks, notably opscode's passenger_apache2, expect the "languages" mash to exist. These cookbooks cause other cookbooks to fail during chefspec tests since the languages mash is referenced in attributes.

Andrew, I decided to submit this pull request because I was quite confused when tests in all cookbooks started failing after I added the opscode cookbook "passenger_apache2". It took me awhile to realize that the failure was caused by that cookbook referencing the languages mash in its attributes file.

If I've somehow missed the boat here, let me know.

-Jim
