### PR TITLE
Support for resource conditionals (not_if and only_if)

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,9 +346,8 @@ chef_run.should install_gem_package 'foo'
 ## Execute
 
 If you make use of the `execute` resource within your cookbook recipes it is
-important to guard for idempotent behaviour. ChefSpec is not smart enough
-at present to be used to verify that an `only_if` or `not_if` condition would
-be met however.
+important to guard for idempotent behaviour. ChefSpec is now smart enough
+to be used to verify that an `only_if` or `not_if` condition would be met.
 
 Assert that a command would be run:
 

--- a/lib/chefspec/chef_runner.rb
+++ b/lib/chefspec/chef_runner.rb
@@ -43,6 +43,13 @@ module ChefSpec
 
         def run_action(action)
           Chef::Log.info("Processing #{self} action #{action} (#{defined_at})") if self.respond_to? :defined_at
+
+          # Utilize Chef::Resource.should_skip? to take not_if and only_if into account
+          if self.should_skip?
+            Chef::Log.info("Skipping #{self} action #{action}")
+            return
+          end
+
           if self.class.methods.include?(:class_variable_get)
             self.class.class_variable_get(:@@runner).resources << self
           else

--- a/spec/chefspec/chef_runner_spec.rb
+++ b/spec/chefspec/chef_runner_spec.rb
@@ -54,6 +54,36 @@ module ChefSpec
         specify{node.hostname.should == 'chefspec'}
         specify{node.kernel.machine.should == 'i386'}
       end
+      context "resource conditionals" do
+        before(:each) do
+          @runner = ChefSpec::ChefRunner.new
+          @resource = Chef::Resource::File.new "file"
+        end
+        it "should not capture a resource when not_if is true" do
+          @resource.not_if.clear
+          @resource.not_if { true }
+          @resource.run_action(:create)
+          @runner.resources.size.should == 0
+        end
+        it "should capture a resource when not_if is false" do
+          @resource.not_if.clear
+          @resource.not_if { false }
+          @resource.run_action(:create)
+          @runner.resources.size.should == 1
+        end
+        it "should capture a resource when only_if is true" do
+          @resource.only_if.clear
+          @resource.only_if { true }
+          @resource.run_action(:create)
+          @runner.resources.size.should == 1
+        end
+        it "should not capture a resource when only_if is false" do
+          @resource.only_if.clear
+          @resource.only_if { false }
+          @resource.run_action(:create)
+          @runner.resources.size.should == 0
+        end
+      end
     end
     describe "#converge" do
       it "should rethrow the exception if a cookbook cannot be found" do


### PR DESCRIPTION
I've taken a stab at adding support for not_if and only_if conditionals in Chef resources.

The way that Chef::Resource handles should_skip in a run is as follows:

``` ruby
return if should_skip?(action)
```

I've enabled chefspec to do the same thing.  If the should_skip? method fails, the resource is not added to the ChefSpec::ChefRunner.resources array.
