### PR TITLE
Bump RSpec dependency to 2.11 in gemspec.

### DIFF
--- a/chefspec.gemspec
+++ b/chefspec.gemspec
@@ -15,5 +15,5 @@ Gem::Specification.new do |s|
   s.add_dependency('chef', chef_version)
   s.add_dependency('erubis', '>= 0')
   s.add_dependency('minitest-chef-handler', '~> 0.6.0')
-  s.add_dependency('rspec', '~> 2.10.0')
+  s.add_dependency('rspec', '~> 2.11.0')
 end


### PR DESCRIPTION
I bumped the RSpec dependency to ~> 2.11.0. All Chefspec specs still pass.
