### PR TITLE
Add support for asserting on notifications

### DIFF
--- a/lib/chefspec.rb
+++ b/lib/chefspec.rb
@@ -10,6 +10,7 @@ if defined?(RSpec)
   require 'chefspec/matchers/package'
   require 'chefspec/matchers/service'
   require 'chefspec/matchers/shared'
+  require 'chefspec/matchers/notifications'
   require 'chefspec/matchers/file_content'
   require 'chefspec/matchers/user'
 end

--- a/lib/chefspec/matchers/notifications.rb
+++ b/lib/chefspec/matchers/notifications.rb
@@ -1,0 +1,43 @@
+require 'chefspec/matchers/shared'
+
+module ChefSpec
+  module Matchers
+
+
+    RSpec::Matchers.define :notify do |expected_resource,expected_resource_action|
+
+      expected_resource.match(/^(.*)\[(.*)\]$/)
+      expected_resource_name = $2
+      expected_resource_type = $1
+      match do |actual_resource|
+        notifications = actual_resource.delayed_notifications
+        notifications+= actual_resource.immediate_notifications
+        notifications.any? do |rs|
+
+          actual_resource_name = rs.resource.name.to_s
+          actual_resource_type = rs.resource.resource_name.to_s
+          actual_resource_action = rs.action
+
+          (actual_resource_name == expected_resource_name) and
+          (actual_resource_type == expected_resource_type) and
+          (actual_resource_action.to_s == expected_resource_action.to_s)
+        end
+      end
+
+      failure_message_for_should do |actual_resource|
+        "expected: ['#{expected_resource_action}, #{expected_resource}']\n" +
+        "     got: #{format_notifications(actual_resource)}  "
+      end
+
+      def format_notifications(resource)
+        notifications = resource.delayed_notifications
+        notifications += resource.immediate_notifications
+        msg="["
+        notifications.each do |res|
+          msg+= "'#{res.action}, #{res.resource.resource_name}[#{res.resource.name}]'"
+        end
+        msg+="]"
+      end
+    end
+  end
+end

--- a/spec/chefspec/matchers/notifications_spec.rb
+++ b/spec/chefspec/matchers/notifications_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+module ChefSpec
+  module Matchers
+    describe :notifications do
+      describe "#notify " do
+        let(:matcher){notify "service[nginx]" ,:restart}
+        it "should define one notify matcher per resource" do
+          matcher_defined?(:notify).should be_true 
+        end
+        it "should match a genuine notification from a resource" do
+          fake_resource = fake_resource_with_notification('nginx','service','restart')
+          matcher.matches?(fake_resource).should be_true
+        end
+        it "should not match a notification from a resource that does not notify the intended resource" do
+          fake_resource = fake_resource_with_notification('nginx','service','stop')
+          matcher.matches?(fake_resource).should be_false
+        end
+
+        def fake_resource_with_notification(name,type,action)
+          notified_resource = double('notified-resource')
+          notified_resource.stub(:resource_name).and_return(type)
+          notified_resource.stub(:name).and_return(name)
+          notified_resource_struct = double('notified-resource-struct')
+          notified_resource_struct.stub(:resource).and_return(notified_resource)
+          notified_resource_struct.stub(:action).and_return(action)
+          fake_resource = double("resource")
+          fake_resource.stub(:delayed_notifications).and_return([notified_resource_struct])
+          fake_resource.stub(:immediate_notifications).and_return([])
+          fake_resource
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
For a recipe containting:
teplate "/etc/nginx/nginx.conf" do
  notifies :restart,"service[nginx]"
end
we should be able to assert

chef_run.template('/etc/nginx/nginx.conf').should notify ("service[nginx]",:restart)
