### PR TITLE
Adding notification support for nested brackets in names

### DIFF
--- a/lib/chefspec/matchers/notifications.rb
+++ b/lib/chefspec/matchers/notifications.rb
@@ -6,7 +6,7 @@ module ChefSpec
 
     RSpec::Matchers.define :notify do |expected_resource,expected_resource_action|
 
-      expected_resource.match(/^(.*)\[(.*)\]$/)
+      expected_resource.match(/^([^\[]*)\[(.*)\]$/)
       expected_resource_name = $2
       expected_resource_type = $1
       match do |actual_resource|

--- a/spec/chefspec/matchers/notifications_spec.rb
+++ b/spec/chefspec/matchers/notifications_spec.rb
@@ -17,6 +17,14 @@ module ChefSpec
           matcher.matches?(fake_resource).should be_false
         end
 
+        context "name regex" do
+          let(:matcher){notify "service[nginx[v1.2.3]]" ,:restart}
+          it 'should allow brackets in the name' do
+            fake_resource = fake_resource_with_notification('nginx[v1.2.3]','service','restart')
+            matcher.matches?(fake_resource).should be_true
+          end
+        end
+
         def fake_resource_with_notification(name,type,action)
           notified_resource = double('notified-resource')
           notified_resource.stub(:resource_name).and_return(type)


### PR DESCRIPTION
I encountered a situation where there was a resource name that included brackets, and the regex in the notification matcher did not account for that.  I've added a test and a fix for the same.
