### PR TITLE
Fix specs to set attributes using node.set in preparation for Chef 11.0

### DIFF
--- a/spec/chefspec/chef_runner_spec.rb
+++ b/spec/chefspec/chef_runner_spec.rb
@@ -59,7 +59,7 @@ module ChefSpec
         file.run_action(:create)
       end
       it "should accept a block to set node attributes" do
-        runner = ChefSpec::ChefRunner.new() {|node| node[:foo] = 'baz'}
+        runner = ChefSpec::ChefRunner.new() {|node| node.set[:foo] = 'baz'}
         runner.node.foo.should == 'baz'
       end
       context "default ohai attributes" do
@@ -86,7 +86,7 @@ module ChefSpec
     describe "#node" do
       it "should allow attributes to be set on the node" do
         runner = ChefSpec::ChefRunner.new
-        runner.node.foo = 'bar'
+        runner.node.set[:foo] = 'bar'
         runner.node.foo.should eq 'bar'
       end
     end
@@ -411,7 +411,7 @@ module ChefSpec
         chef_run.to_s.should == 'chef_run'
       end
       it "should not include node attributes" do
-        chef_run.node.foo = 'bar'
+        chef_run.node.set[:foo] = 'bar'
         chef_run.node.automatic_attrs[:platform] = 'solaris'
         chef_run.converge('apache2::default').to_s.should == 'chef_run: recipe[apache2::default]'
       end


### PR DESCRIPTION
Fixes the following warning with Chef 10.6.2:

```
WARN: Setting attributes without specifying a precedence is deprecated and will be
removed in Chef 11.0. To set attributes at normal precedence, change code like:
`node["key"] = "value"` # Not this
to:
`node.set["key"] = "value"` # This
```
