### PR TITLE
Fix failure reporting of include_recipe

### DIFF
--- a/lib/chefspec/matchers/include_recipe.rb
+++ b/lib/chefspec/matchers/include_recipe.rb
@@ -10,7 +10,7 @@ module ChefSpec
 
       failure_message_for_should do |chef_run|
         "expected: ['#{expected_recipe}']\n" +
-        "     got: #{chef_run.node.run_state.recipes}"
+        "     got: #{chef_run.node.run_state[:seen_recipes]}"
       end
     end
   end


### PR DESCRIPTION
Commit ea78a801c534f848074b9811dd5f0ae2f10776d8 changed the matcher but left the failure_message part intact.
