### PR TITLE
Support message attribute and regexp matching for log resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,12 @@ Assert that a log statement would be logged:
 chef_run.should log 'A log message from my recipe'
 ```
 
+Assert that at least one log statement would match a specified regexp:
+
+```ruby
+chef_run.should log(/bacon \d+/)
+```
+
 If you want to be able to view the log output at the console you can control
 the logging level when creating an instance of `ChefRunner` as below:
 

--- a/features/support/rspec_helpers.rb
+++ b/features/support/rspec_helpers.rb
@@ -315,7 +315,7 @@ module ChefSpec
             end.converge 'example::default'
           end
           it "should log the node foo" do
-            chef_run.should log "The value of node.foo is: bar"
+            chef_run.should log /node.foo is: bar$/
           end
         end
       }

--- a/lib/chefspec/matchers/log.rb
+++ b/lib/chefspec/matchers/log.rb
@@ -10,9 +10,9 @@ module ChefSpec
             false
           elsif resource.respond_to?(:message)
             # Chef 10.18 added message attribute to the log resource
-            resource.message == message
+            message === resource.message
           else
-            resource.name == message
+            message === resource.name
           end
         end
       end

--- a/spec/chefspec/matchers/log_spec.rb
+++ b/spec/chefspec/matchers/log_spec.rb
@@ -29,6 +29,16 @@ module ChefSpec
           matcher.matches?({:resources => [fake_old_log_resource('Hello World')]}).should be true
         end
 
+        context "regexp" do
+          let(:matcher) { log(/^Hel+/) }
+          it "should match when a matching log resource exists" do
+            matcher.matches?({:resources => [fake_log_resource('Hello World')]}).should be true
+          end
+          it "should not match when only a different log resource exists" do
+            matcher.matches?({:resources => [fake_log_resource('Hola Mundo')]}).should be false
+          end
+        end
+
         def fake_log_resource(name, message = nil)
           fake_resource = fake_old_log_resource(name)
           fake_resource.stub(:message).and_return(message || name)


### PR DESCRIPTION
Chef 10.18.0 added "message" attribute to the log resource: [CHEF-3006](http://tickets.opscode.com/browse/CHEF-3006). Prefer it for matching, but fallback to "name" attribute on older Chef versions.

Also in addition to a String that has to match the whole log message, allow matching with a Regexp (or any other object that returns true for `object === <log message>`).
