### PR TITLE
Use Rubygems 1.8 since 2.0 is broken with Chef

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+before_install: gem update --system 1.8.25
 rvm:
   - ree       # Remove on July 1, 2013
   - 1.9.3


### PR DESCRIPTION
:warning: trying to figure out why the build is broken on Ruby 2.0.0 and 1.8.7
