### PR TITLE
Remove unneeded dependency on moneta

### DIFF
--- a/chefspec.gemspec
+++ b/chefspec.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
   s.add_dependency('erubis')
   s.add_dependency('fauxhai', '~> 0.1')
   s.add_dependency('minitest-chef-handler', '~> 0.6.0')
-  s.add_dependency('moneta', '< 0.7.0') # https://github.com/opscode/chef/commit/c6b6103e3befa355c2645c35fc3b8ba0159375f0
   s.add_dependency('rspec', '~> 2.13.0')
 
   # Development Dependencies


### PR DESCRIPTION
See issue #119. moneta is no longer needed since Chef >= 11 doesn't use it, and any user who's using Chef 10 should get moneta from Chef.
