### PR TITLE
Relax gemspec constraints on rake, rspec and minitest-chef-handler

### DIFF
--- a/chefspec.gemspec
+++ b/chefspec.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_dependency('erubis')
   s.add_dependency('fauxhai', '~> 0.1')
   s.add_dependency('minitest-chef-handler', '>= 0.6.0')
-  s.add_dependency('rspec')
+  s.add_dependency('rspec', '~> 2.0')
 
   # Development Dependencies
   s.add_development_dependency('rake')


### PR DESCRIPTION
Hey @sethvargo,

I'm submitting this PR to relax some of the gemspec constraints in chefspec, as a point of discussion. I don't think the minitest-chef-handler one should be too controversial since 1.0.0 was just released, but I'm unsure about rake and rspec. Is there a reason you pinned them as so?

I removed all the constraints here and ran the tests under Bundler, thereby using the following:

```
rake (10.0.4)
rspec (2.13.0)
  rspec-core (~> 2.13.0)
  rspec-expectations (~> 2.13.0)
  rspec-mocks (~> 2.13.0)
rspec-core (2.13.1)
rspec-expectations (2.13.0)
  diff-lcs (>= 1.1.3, < 2.0)
```

and everything passed.
