### PR TITLE
Add cache_options to the Chef::Config

### DIFF
--- a/lib/chefspec/chef_runner.rb
+++ b/lib/chefspec/chef_runner.rb
@@ -72,6 +72,7 @@ module ChefSpec
 
       Chef::Config[:solo] = true
       Chef::Config[:cache_type] = "Memory"
+      Chef::Config[:cache_options] = { :path => "#{ENV['HOME']}/.chef/checksums" }
       Chef::Cookbook::FileVendor.on_create { |manifest| Chef::Cookbook::FileSystemFileVendor.new(manifest) }
       Chef::Config[:cookbook_path] = @options[:cookbook_path]
       Chef::Config[:client_key] = nil


### PR DESCRIPTION
This should eliminate the need for a `knife.rb` for testing on third-party systems (like Travis) that don't have global write access, since Chef defaults the `cache_path` to `/var/chef/cache`
