### PR TITLE
allow passing json files to fauxhai via the :path option

### DIFF
--- a/lib/chefspec/chef_runner.rb
+++ b/lib/chefspec/chef_runner.rb
@@ -152,9 +152,9 @@ module ChefSpec
     # @param [Ohai::System] ohai The ohai instance to set fake attributes on
     def fake_ohai(ohai)
       data = if @options.has_key?(:ohai_data_path)
-              ::Fauxhai::Mocker.new(:path => @options[:ohai_data_path]).data
+              Fauxhai::Mocker.new(:path => @options[:ohai_data_path]).data
              else
-              ::Fauxhai::Mocker.new(:platform => @options[:platform], :version => @options[:version]).data
+              Fauxhai::Mocker.new(:platform => @options[:platform], :version => @options[:version]).data
              end
       data.each_pair do |attribute, value|
         ohai[attribute] = value


### PR DESCRIPTION
Fauxhai has added the support for :path which allows any json files to be passed in as ohai data, this will help testing recipes that have cloud specific or any attributes that are not available via normal platforms
