### PR TITLE
Upgrade Fauxhai dependency to allow also v1.x

### DIFF
--- a/chefspec.gemspec
+++ b/chefspec.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency('chef', '>= 10.0')
   s.add_dependency('erubis')
-  s.add_dependency('fauxhai', '~> 0.1')
+  s.add_dependency('fauxhai', '>= 0.1.1', '< 2.0')
   s.add_dependency('minitest-chef-handler', '>= 0.6.0')
   s.add_dependency('rspec', '~> 2.0')
 


### PR DESCRIPTION
v1.0.0 has been released. Besides few fixture chenges and additions it includes new `path` option for specifying a local fixture data file. It also drops undocumented support for default platform version (except for the special "fauxhai" platform).

IMHO a minor version number bump for chefspec is sufficient as none of the documentation never indicated that the `version` was optional.  Calling `ChefSpec::ChefRunner.new` without any options stays supported as earlier.
