### PR TITLE
Add described_recipe and described_cookbook helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,22 @@ Let's step through this spec file to see what is happening:
    should have been installed. Normally you will have multiple `it` blocks per
    recipe, each making a single assertion.
 
+Instead of hardcoding recipe name everywhere, it's possible to use ```described_recipe```
+and ```described_cookbook``` methods which for the above example will return ```example::default```
+and ```example``` appropriately. These helpers can be used like ```described_class``` is used
+in RSpec - to DRY the name of described cookbook/recipe making specs more refactoring proof.
+
+```ruby
+require "chefspec"
+
+describe "example::default" do
+  let(:chef_run) { ChefSpec::ChefRunner.new.converge described_recipe }
+  it "includes another_recipe" do
+    expect(chef_run).to include_recipe "#{described_cookbook}::another_recipe"
+  end
+end
+```
+
 Generating an Example
 ---------------------
 Ideally you should be writing your specs in tandem with your recipes and

--- a/lib/chefspec.rb
+++ b/lib/chefspec.rb
@@ -20,6 +20,11 @@ if defined?(RSpec)
   require 'chefspec/matchers/env'
   require 'chefspec/matchers/include_recipe'
   require 'chefspec/matchers/script'
+
+  require 'chefspec/helpers/describe'
+  RSpec.configure do |c|
+    c.include ChefSpec::Helpers::Describe
+  end
 end
 
 require 'chefspec/minitest'

--- a/lib/chefspec/helpers/describe.rb
+++ b/lib/chefspec/helpers/describe.rb
@@ -1,0 +1,13 @@
+module ChefSpec
+  module Helpers
+    module Describe
+      def described_recipe
+        self.class.metadata[:example_group][:description_args].first
+      end
+
+      def described_cookbook
+        described_recipe.split('::').first
+      end
+    end
+  end
+end

--- a/spec/chefspec/helpers/describe_spec.rb
+++ b/spec/chefspec/helpers/describe_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+module ChefSpec
+  module Helpers
+    describe Describe do
+      describe 'nginx::source' do
+        it 'sets described_recipe to nginx::source' do
+          described_recipe.should == 'nginx::source'
+        end
+
+        it 'sets described_cookbook to nginx' do
+          described_cookbook.should == 'nginx'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
It will allow to DRY the cookbook and recipe names in specs to avoid extra work when refactoring.
