### PR TITLE
Fix ohai plugin reloader by providing dummy config

### DIFF
--- a/lib/chefspec/chef_runner.rb
+++ b/lib/chefspec/chef_runner.rb
@@ -82,6 +82,11 @@ module ChefSpec
       Chef::Config[:cookbook_path] = cookbook_paths
       Chef::Config[:client_key] = nil
 
+      # it should be saved to an instance variable to prevent automatic
+      # unlinking during garbage collection
+      @dummy_config = Tempfile.new 'chef-config'
+      Chef::Config[:config_file] = @dummy_config.path
+
       # As of Chef 11, Chef uses custom formatters which munge the RSpec output.
       # This uses a custom formatter which basically tells Chef to shut up.
       Chef::Config.add_formatter('chefspec') if Chef::Config.respond_to?(:add_formatter)


### PR DESCRIPTION
```
================================================================================
Recipe Compile Error in /Users/akhkharu/projects/chef/chef-rails-frontend/vendor/cookbooks/chef-rails-frontend/recipes/default.rb
================================================================================

TypeError
---------
can't convert nil into String

Cookbook Trace:
---------------
  /Users/akhkharu/projects/chef/chef-rails-frontend/vendor/cookbooks/ohai/recipes/default.rb:51:in `read'
  /Users/akhkharu/projects/chef/chef-rails-frontend/vendor/cookbooks/ohai/recipes/default.rb:51:in `from_file'
  /Users/akhkharu/projects/chef/chef-rails-frontend/vendor/cookbooks/nginx/recipes/ohai_plugin.rb:39:in `from_file'
  /Users/akhkharu/projects/chef/chef-rails-frontend/vendor/cookbooks/nginx/recipes/source.rb:40:in `from_file'
  /Users/akhkharu/projects/chef/chef-rails-frontend/vendor/cookbooks/chef-rails-frontend/recipes/default.rb:1:in `from_file'
  /Users/akhkharu/projects/chef/chef-rails-frontend/spec/default_spec.rb:5:in `block (2 levels) in <top (required)>'
  /Users/akhkharu/projects/chef/chef-rails-frontend/spec/default_spec.rb:20:in `block (2 levels) in <top (required)>'

Relevant File Content:
----------------------
/Users/akhkharu/projects/chef/chef-rails-frontend/vendor/cookbooks/ohai/recipes/default.rb:

 44:  resource = ohai 'custom_plugins' do
 45:    action :nothing
 46:  end
 47:
 48:  # only reload ohai if new plugins were dropped off OR
 49:  # node['ohai']['plugin_path'] does not exists in client.rb
 50:  if reload_ohai ||
 51>>   !(::IO.read(Chef::Config[:config_file]) =~ /Ohai::Config\[:plugin_path\]\s*<<\s*["']#{node['ohai']['plugin_path']}["']/)
 52:
 53:    resource.run_action(:reload)
 54:  end
 55:
```
