### PR TITLE
Corrected testing chef_gem syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ expect(chef_run).to install_gem_package 'foo'
 ```
 
 ```ruby
-expect(chef_run).to install_chef_gem_package 'chef-foo'
+expect(chef_run).to install_chef_gem 'chef-foo'
 ```
 
 ### Execute


### PR DESCRIPTION
The `install_chef_gem_package` syntax is incorrect.  Corrected to `install_chef_gem`.
