### PR TITLE
Fix failure message of `create_remote_file` without attributes

### DIFF
--- a/lib/chefspec/matchers/file.rb
+++ b/lib/chefspec/matchers/file.rb
@@ -74,6 +74,7 @@ module ChefSpec
       failure_message_for_should do |actual|
         message = "No remote_file named '#{path}' found"
         message << " with:\n#{@attributes}" unless @attributes.nil?
+        message
       end
 
       failure_message_for_should_not do |actual|


### PR DESCRIPTION
Ensure we return the string also if `@attributes` is nil.
