### PR TITLE
Add create_remote_file_if_missing matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,21 @@ expect(chef_run).to create_remote_file('/tmp/foo.tar.gz').with(
 )
 ```
 
+Assert that a remote file would be created if it did not exist:
+
+```ruby
+expect(chef_run).to create_remote_file_if_missing '/tmp/foo.tar.gz'
+```
+
+Assert that a remote file with specific attributes would be created if it did not exist:
+
+```ruby
+expect(chef_run).to create_remote_file_if_missing('/tmp/foo.tar.gz').with(
+  :source => 'http://www.example.com/foo.tar.gz',
+  :checksum => 'deadbeef'
+)
+```
+
 Assert that a file would be created from cookbook_file ressource:
 
 ```ruby

--- a/features/step_definitions/file_steps.rb
+++ b/features/step_definitions/file_steps.rb
@@ -22,6 +22,10 @@ Given 'a Chef cookbook with a recipe that creates a remote file' do
   recipe_with_remote_file
 end
 
+Given 'a Chef cookbook with a recipe that creates a missing remote file' do
+  recipe_with_missing_remote_file
+end
+
 Given 'a Chef cookbook with a recipe that sets file ownership' do
   recipe_sets_file_ownership('file')
 end
@@ -52,6 +56,10 @@ end
 
 Given 'the recipe has a spec example that expects the remote file to be created' do
   spec_expects_file(:remote_file)
+end
+
+Given 'the recipe has a spec example that expects the missing remote file to be created' do
+  spec_expects_file(:remote_file_if_missing)
 end
 
 Given 'the recipe has a spec example that expects the file to be set to be owned by a specific user' do

--- a/features/support/example_helpers.rb
+++ b/features/support/example_helpers.rb
@@ -404,6 +404,15 @@ module ChefSpec
       }
     end
 
+    def recipe_with_missing_remote_file
+      write_file 'cookbooks/example/recipes/default.rb', %q{
+        remote_file "hello-world.txt" do
+          source 'http://www.google.com/robots.txt'
+          action :create_if_missing
+        end
+      }
+    end
+
     def recipe_creates_user
       write_file 'cookbooks/example/recipes/default.rb', %q{
         user "foo" do

--- a/features/write_examples_for_files.feature
+++ b/features/write_examples_for_files.feature
@@ -48,6 +48,12 @@ Feature: Write examples for files
     When the recipe example is successfully run
     Then the file will not have been created
 
+  Scenario: Create a remote file only if the file is missing
+    Given a Chef cookbook with a recipe that creates a missing remote file
+    And the recipe has a spec example that expects the missing remote file to be created
+    When the recipe example is successfully run
+    Then the file will not have been created
+
   Scenario: Check file ownership
     Given a Chef cookbook with a recipe that sets file ownership
     And the recipe has a spec example that expects the file to be set to be owned by a specific user

--- a/lib/chefspec/matchers/file.rb
+++ b/lib/chefspec/matchers/file.rb
@@ -11,74 +11,76 @@ module ChefSpec
       end
     end
 
-    RSpec::Matchers.define :create_remote_file do |path|
-      match do |chef_run|
-        if @attributes
-          chef_run.resources.any? do |resource|
-            expected_remote_file?(resource,path) &&
-              expected_attributes?(resource)
-          end
-        else
-          chef_run.resources.any? do |resource|
-            expected_remote_file?(resource,path)
+    {:create_remote_file => :create, :create_remote_file_if_missing => :create_if_missing}.each do |matcher, corr_action|
+      RSpec::Matchers.define matcher do |path|
+        match do |chef_run|
+          if @attributes
+            chef_run.resources.any? do |resource|
+              expected_remote_file?(resource,path,corr_action) &&
+                expected_attributes?(resource)
+            end
+          else
+            chef_run.resources.any? do |resource|
+              expected_remote_file?(resource,path,corr_action)
+            end
           end
         end
-      end
 
-      chain :with do |attributes|
-        @attributes = attributes
-      end
+        chain :with do |attributes|
+          @attributes = attributes
+        end
 
-      def expected_remote_file?(resource,path)
-        # The resource action *might* be an array!
-        # (see https://tickets.opscode.com/browse/CHEF-2094)
-        action = resource.action.is_a?(Array) ? resource.action.first :
-          resource.action
-        resource_type(resource) == 'remote_file' &&
-          resource.path         == path &&
-          action.to_sym         == :create
-      end
+        def expected_remote_file?(resource,path,corr_action)
+          # The resource action *might* be an array!
+          # (see https://tickets.opscode.com/browse/CHEF-2094)
+          action = resource.action.is_a?(Array) ? resource.action.first :
+            resource.action
+          resource_type(resource) == 'remote_file' &&
+            resource.path         == path &&
+            action.to_sym         == corr_action
+        end
 
-      def expected_attributes?(resource)
-        @attributes.all? do |attribute,expected|
-          actual = resource.send(attribute)
-          attribute.to_sym == :source ? equal_source?(actual, expected) :
+        def expected_attributes?(resource)
+          @attributes.all? do |attribute,expected|
+            actual = resource.send(attribute)
+            attribute.to_sym == :source ? equal_source?(actual, expected) :
+              actual == expected
+          end
+        end
+
+        # Compare two remote_file source attributes for equality.
+        #
+        # @param actual [String, Array<String>] The actual source.
+        # @param expected [String, Array<String>] The expected source.
+        # @return [Boolean] true if they are equal or false if not.
+        def equal_source?(actual, expected)
+          # NOTE: Chef stores the source attribute internally as an array since
+          # version 11 in order to support mirrors.
+          # (see http://docs.opscode.com/breaking_changes_chef_11.html#remote-file-mirror-support-may-break-subclasses)
+
+          # Handle wrong formated expectation for Chef versions >= 11.
+          if actual.is_a?(Array) && expected.is_a?(String)
+            actual == [expected]
+
+          # Handle wrong formated expectation for Chef versions < 11.
+          elsif actual.is_a?(String) && expected.is_a?(Array)
+            [actual] == expected
+
+          # Else assume the actual matches the expected type (String or Array).
+          else
             actual == expected
+          end
         end
-      end
 
-      # Compare two remote_file source attributes for equality.
-      #
-      # @param actual [String, Array<String>] The actual source.
-      # @param expected [String, Array<String>] The expected source.
-      # @return [Boolean] true if they are equal or false if not.
-      def equal_source?(actual, expected)
-        # NOTE: Chef stores the source attribute internally as an array since
-        # version 11 in order to support mirrors.
-        # (see http://docs.opscode.com/breaking_changes_chef_11.html#remote-file-mirror-support-may-break-subclasses)
-
-        # Handle wrong formated expectation for Chef versions >= 11.
-        if actual.is_a?(Array) && expected.is_a?(String)
-          actual == [expected]
-
-        # Handle wrong formated expectation for Chef versions < 11.
-        elsif actual.is_a?(String) && expected.is_a?(Array)
-          [actual] == expected
-
-        # Else assume the actual matches the expected type (String or Array).
-        else
-          actual == expected
+        failure_message_for_should do |actual|
+          message = "No remote_file named '#{path}' for action #{corr_action} found"
+          message << " with:\n#{@attributes}" unless @attributes.nil?
+          message
         end
-      end
 
-      failure_message_for_should do |actual|
-        message = "No remote_file named '#{path}' found"
-        message << " with:\n#{@attributes}" unless @attributes.nil?
-        message
-      end
-
-      failure_message_for_should_not do |actual|
-        "Found remote_file named '#{path}' that should not exist."
+        failure_message_for_should_not do |actual|
+          "Found remote_file named '#{path}' that should not exist."
+        end
       end
     end
   end


### PR DESCRIPTION
The `create_remote_file` matcher doesn't work if the action is `:create_if_missing`. Most of my `remote_file` resources use this action, so it would be useful to have a matcher for this. (And chefspec 0.9.0 didn't check the action attribute so I was able to use that matcher.)

This addresses part of issue #118.

My ruby-fu is not strong; feedback/suggestions welcome.
