### PR TITLE
add cookbook_file to accepted_types for create_file

### DIFF
--- a/lib/chefspec/matchers/shared.rb
+++ b/lib/chefspec/matchers/shared.rb
@@ -29,7 +29,7 @@ def define_resource_matchers(actions, resource_types, name_attribute)
     RSpec::Matchers.define "#{action}_#{resource_type}".to_sym do |name|
       match do |chef_run|
         accepted_types = [resource_type.to_s]
-        accepted_types << 'template' << 'cookbook_file' if action.to_s == 'create' and resource_type.to_s == 'file'
+        accepted_types += ['template', 'cookbook_file']  if action.to_s == 'create' and resource_type.to_s == 'file'
         chef_run.resources.any? do |resource|
           accepted_types.include? resource_type(resource) and resource.send(name_attribute) == name and
               resource_actions(resource).include? action.to_s


### PR DESCRIPTION
After spending a frustrating 30 minutes trying to figure out why my recipe wasn't passing my tests for create_file, I found that using cookbook_file doesn't work with create_file.
