### PR TITLE
Moved chefspec formatter registration into the ChefRunner.  Addresses #166

### DIFF
--- a/lib/chefspec/chef_runner.rb
+++ b/lib/chefspec/chef_runner.rb
@@ -18,7 +18,19 @@ module ChefSpec
 
     @resources = []
 
-    @@needs_formatter_registered = Chef::Config.respond_to?(:add_formatter)
+    @needs_formatter_registered = Chef::Config.respond_to?(:add_formatter)
+    @nfr_mutex = Mutex.new
+
+    def self.register_formatter
+      return unless @needs_formatter_registered
+      @nfr_mutex.synchronize do
+        return unless @needs_formatter_registered
+        @needs_formatter_registered = false
+        # As of Chef 11, Chef uses custom formatters which munge the RSpec output.
+        # This uses a custom formatter which basically tells Chef to shut up.
+        Chef::Config.add_formatter('chefspec')
+      end
+    end
 
     attr_accessor :resources
     attr_reader :step_into
@@ -128,12 +140,7 @@ module ChefSpec
       @dummy_config = Tempfile.new 'chef-config'
       Chef::Config[:config_file] = @dummy_config.path
 
-      # As of Chef 11, Chef uses custom formatters which munge the RSpec output.
-      # This uses a custom formatter which basically tells Chef to shut up.
-      if @@needs_formatter_registered
-        Chef::Config.add_formatter('chefspec')
-        @@needs_formatter_registered = false
-      end
+      self.class.register_formatter
 
       Chef::Log.verbose = true if Chef::Log.respond_to?(:verbose)
       Chef::Log.level(@options[:log_level])


### PR DESCRIPTION
This prevents the duplicate registrations.  Obviously,  I could have tested ChefRunner#initialize directly, but that seems to miss the point.  The failing case was exposed with the following type of situation:

``` ruby
describe "context 1" do
  let(:chef_run) ...
  it "does what I want" do
    chef_run
  end
end

describe "context 2" do
  let(:chef_run) ...
  it "still does" do
    expect{chef_run}.to raise_error(StandardError)
  end
end
```

If the second run fails in the compile stage, the twice-registerd chefspec formatter will twice-report the information relating to the fail of the compile.
