### PR TITLE
fixes #described_recipe helper

### DIFF
--- a/lib/chefspec/helpers/describe.rb
+++ b/lib/chefspec/helpers/describe.rb
@@ -2,7 +2,11 @@ module ChefSpec
   module Helpers
     module Describe
       def described_recipe
-        self.class.metadata[:example_group][:description_args].first
+        metahash = self.class.metadata
+        while metahash.has_key? :example_group
+          metahash = metahash[:example_group]
+        end
+        metahash[:description_args].first
       end
 
       def described_cookbook

--- a/spec/chefspec/helpers/describe_spec.rb
+++ b/spec/chefspec/helpers/describe_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 module ChefSpec
   module Helpers
-    describe Describe do
+    module Describe
       describe 'nginx::source' do
         it 'sets described_recipe to nginx::source' do
           described_recipe.should == 'nginx::source'
@@ -10,6 +10,16 @@ module ChefSpec
 
         it 'sets described_cookbook to nginx' do
           described_cookbook.should == 'nginx'
+        end
+
+        context 'in a nested context' do
+          it 'still sets described_recipe to nginx::source' do
+            described_recipe.should == 'nginx::source'
+          end
+
+          it 'still sets described_cookbook to nginx' do
+            described_cookbook.should == 'nginx'
+          end
         end
       end
     end


### PR DESCRIPTION
This was broken when using nested example groups because it would fail to traverse up to the top-level example, which is what I feel the correct behavior should be.

``` ruby
describe "cookbook::recipe" do
  describe "some aspect" do
    it 'does something' do
      # #described_recipe helper returned 'does something'
    end
  end
end
```

I wrote a test to expose the bug and implemented a fix.
