### PR TITLE
Fix for Chef 11.6 rendering issue for templates

### DIFF
--- a/lib/chefspec/matchers/shared.rb
+++ b/lib/chefspec/matchers/shared.rb
@@ -60,7 +60,7 @@ def render(template, node, template_finder)
     context[:template_finder] = template_finder
     Erubis::Context.send(:include, Chef::Mixin::Template::ChefContext)
   end
-  Erubis::Eruby.new(IO.read(template_path(template, node))).evaluate(context)
+  Erubis::Eruby.new(IO.read(template_path(template, node))).evaluate(context.node)
 end
 
 # Given a template, return the path on disk.


### PR DESCRIPTION
[#177]

It seems that by adding .node to the end of the context it properly renders in Chef 11.6 and also works with Chef 11.4.4.

I couldn't come up with a test since you seem to be mocking out the rendering. This still passes and may not be the best to merge, but it gives a starting point to solve the issue.
