### PR TITLE
Add missing optional argument to `Hash#respond_to?` monkey patch

### DIFF
--- a/lib/chefspec/monkey_patches/hash.rb
+++ b/lib/chefspec/monkey_patches/hash.rb
@@ -13,7 +13,7 @@ class Hash
 
   # Monkey-patch to stdlib Hash to correspond to Mash-style lookup
   # @see {Hash#respond_to?}
-  def respond_to?(m)
+  def respond_to?(m, include_private = false)
     if has_key?(m.to_sym) || has_key?(m.to_s)
       true
     else


### PR DESCRIPTION
[`Object#respond_to?`](http://www.ruby-doc.org/core-1.9.3/Object.html#method-i-respond_to-3F) has an optional second argument.
