### PR TITLE
improve error messages after the regexp patch

### DIFF
--- a/lib/chefspec/matchers/shared.rb
+++ b/lib/chefspec/matchers/shared.rb
@@ -32,16 +32,19 @@ def define_resource_matchers(actions, resource_types, name_attribute)
         accepted_types = [resource_type.to_s]
         accepted_types += ['template', 'cookbook_file']  if action.to_s == 'create' and resource_type.to_s == 'file'
         chef_run.resources.any? do |resource|
-          (accepted_types.include? resource_type(resource) and
-           name === resource.send(name_attribute) and
-           resource_actions(resource).include? action.to_s)
+          if (accepted_types.include? resource_type(resource) and
+              name === resource.send(name_attribute) and
+              resource_actions(resource).include? action.to_s)
+            @resource_name = resource.send(name_attribute)
+            true
+          end
         end
       end
       failure_message_for_should do |actual|
-        "No #{resource_type} resource named '#{name}' with action :#{action} found."
+        "No #{resource_type} resource matching name '#{name}' with action :#{action} found."
       end
       failure_message_for_should_not do |actual|
-        "Found #{resource_type} resource named '#{name}' with action :#{action} that should not exist."
+        "Found #{resource_type} resource named '#{@resource_name}' matching name: '#{name}' with action :#{action} that should not exist."
       end
     end
   end

--- a/spec/chefspec/matchers/shared_spec.rb
+++ b/spec/chefspec/matchers/shared_spec.rb
@@ -28,11 +28,13 @@ module ChefSpec
         end
         it "should define a should failure message" do
           define_resource_matchers([:climb], [:mountain], :name)
-          climb_mountain('everest').failure_message_for_should.should == "No mountain resource named 'everest' with action :climb found."
+          climb_mountain('everest').failure_message_for_should.should == "No mountain resource matching name 'everest' with action :climb found."
         end
-        it "should define a should_not failure message" do
+        it "should define a dynamically built should_not failure message" do
           define_resource_matchers([:climb], [:mountain], :name)
-          climb_mountain('Kilimanjaro').failure_message_for_should_not.should == "Found mountain resource named 'Kilimanjaro' with action :climb that should not exist."
+          matcher = climb_mountain(/Kili/)
+          matcher.matches?({ resources: [{:resource_name => 'mountain', :action => 'climb', :name => 'Kilimanjaro'}]})
+          matcher.failure_message_for_should_not.should == "Found mountain resource named 'Kilimanjaro' matching name: '(?-mix:Kili)' with action :climb that should not exist."
         end
       end
 


### PR DESCRIPTION
This displays the resource that matched the regexp in 
failure_message_for_should_not which can be very useful when using regexp
matchers
