### PR TITLE
fixes ChefRunner#default_cookbook_path

### DIFF
--- a/lib/chefspec/chef_runner.rb
+++ b/lib/chefspec/chef_runner.rb
@@ -245,7 +245,9 @@ module ChefSpec
     #
     # @return [String] The path to the cookbooks directory
     def default_cookbook_path
-      Pathname.new(File.join(caller(2).first.split(':').slice(0..-3).join(':'), '..', '..', '..')).cleanpath.to_s
+      calling_spec = caller(2).first.split(':').slice(0..-3).join(':')
+      bits = calling_spec.split(File::SEPARATOR)
+      File.expand_path(File.join(bits[0...bits.index('spec')], '..'))
     end
 
     # The cookbook path, appended with some "common" directories to search

--- a/spec/chefspec/chef_runner/nested_spec.rb
+++ b/spec/chefspec/chef_runner/nested_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+module ChefSpec
+  describe ChefRunner do
+    describe '#initialize' do
+      it 'does not change the default cookbook path if examples are nested in subdirs under /spec' do
+        Chef::Config[:cookbook_path] = nil
+        ChefSpec::ChefRunner.new
+        expect(Chef::Config[:cookbook_path]).to include(cookbook_path)
+      end
+    end
+  end
+end

--- a/spec/chefspec/chef_runner_spec.rb
+++ b/spec/chefspec/chef_runner_spec.rb
@@ -11,7 +11,7 @@ module ChefSpec
       it 'sets the chef cookbook path to a default if not provided' do
         Chef::Config[:cookbook_path] = nil
         ChefSpec::ChefRunner.new
-        expect(Chef::Config[:cookbook_path]).not_to be_nil
+        expect(Chef::Config[:cookbook_path]).to include(cookbook_path)
       end
 
       it 'sets the chef cookbook path to any provided value' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,10 +17,17 @@ def matcher_defined?(matcher)
   RSpec::Matchers.method_defined?(matcher)
 end
 
+# The assumption is that the specs are contained in a cookbook, and the cookbook
+# lives with its siblings nested in a directory (i.e. the cookbook path ).
+#
+# @return [String] path to the directory containing this project
+def cookbook_path
+  File.expand_path('../../..', __FILE__)
+end
+
 class ErrorStub < StandardError
   def initialize(*args)
     super(args.first)
     @args = args
   end
 end
-


### PR DESCRIPTION
The method would fails to produce the correct path as soon as you start nesting spec files in subdirs under spec/.
I tried to stay as platform-agnostic as I could for this implementation (windows folks).

Lastly, I preserved this section of the original method, but I truly don't understand the point of it:

`caller(2).first.split(':').slice(0..-3).join(':')`

Wouldn't the following suffice?

`caller(2).first.split(':').first`

Perhaps there's some aspect of the `caller` method that I'm unaware of currently. 
