### PR TITLE
Support Berkshelf 3.0

### DIFF
--- a/lib/chefspec/berkshelf.rb
+++ b/lib/chefspec/berkshelf.rb
@@ -25,24 +25,17 @@ module ChefSpec
     def setup!
       tmpdir = Dir.mktmpdir
 
-      vendor_cookbooks(tmpdir)
+      ::Berkshelf.ui.mute do
+        if ::Berkshelf::Berksfile.method_defined?(:vendor)
+          FileUtils.rm_rf(tmpdir)
+          ::Berkshelf::Berksfile.from_file('Berksfile').vendor(tmpdir)
+        else
+          ::Berkshelf::Berksfile.from_file('Berksfile').install(path: tmpdir)
+        end
+      end
 
       ::RSpec.configure do |config|
         config.cookbook_path = tmpdir
-      end
-    end
-
-    private
-
-    def vendor_cookbooks(path)
-      ::Berkshelf.ui.mute do
-        berksfile = ::Berkshelf::Berksfile.from_file('Berksfile')
-        if berksfile.respond_to?(:vendor)
-          FileUtils.rm_rf(path)
-          berksfile.vendor(path)
-        else
-          berksfile.install(path: path)
-        end
       end
     end
   end


### PR DESCRIPTION
Berkshelf v3.0.0 will replace `Berksfile#install(:path => path)` with new method, `Berksfile#vendor(path)`. Check its existence to support both versions.
