### PR TITLE
Fix Berkshelf 3.0 integration

### DIFF
--- a/lib/chefspec/berkshelf.rb
+++ b/lib/chefspec/berkshelf.rb
@@ -40,7 +40,7 @@ module ChefSpec
     # Destroy the installed Berkshelf at the temporary directory.
     #
     def teardown!
-      FileUtils.rm_rf(@tmpdir) if File.exists?(@tmpdir)
+      FileUtils.rm_rf(@tmpdir)
     end
   end
 end


### PR DESCRIPTION
`Berksfile#vendor` [requires](https://github.com/RiotGames/berkshelf/blob/7e840736aec441721fa17badc75d6d58ddce414c/lib/berkshelf/berksfile.rb#L610-L613) that the destination directory doesn't exis. On the other hand, `Berksfile#install` on Berkshelf <3.0 [will delete](https://github.com/RiotGames/berkshelf/blob/v2.0.10/lib/berkshelf/berksfile.rb#L53) the destination directory by itself, so we don't need to.

The second commit removes the unnecessary directory existence check before `rm -rf`.

Feel free to make review fixes yourselves before merging if you want to. Seems that I can't always follow your preferred style. =)
