### PR TITLE
Random doc fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,16 +10,16 @@ All contributions are welcome to be submitted for review for inclusion, but befo
 
 Also, please be patient as not all items will be tested or reviewed immediately by the core team.
 
-Pleas be receptive and responsive to feedback about your additions or changes. The core team and/or other community members may make suggestions or ask questions about your change. This is part of the review process, and helps everyone to understand what is happening, why it is happening, and potentially optimizes your code.
+Please be receptive and responsive to feedback about your additions or changes. The core team and/or other community members may make suggestions or ask questions about your change. This is part of the review process, and helps everyone to understand what is happening, why it is happening, and potentially optimizes your code.
 
-If you're looking to contribute but aren't sure where to start, check ou the [open issues](https://github.com/sethvargo/chefspec/issues?state=open).
+If you're looking to contribute but aren't sure where to start, check out the [open issues](https://github.com/sethvargo/chefspec/issues?state=open).
 
 
 Will Not Merge
 --------------
 This section details, specifically, Pull Requests or features that will _not_ be merged:
 
-1. Machers for non-Chef core resources. ChefSpec 3.0 introduced a way for cookbook maintiners to [package matchers _with_ their cookbooks](https://github.com/sethvargo/chefspec/tree/unify_matchers#packaging-lwrp-matchers) at distribution time.
+1. Matchers for non-Chef core resources. ChefSpec 3.0 introduced a way for cookbook maintainers to [package matchers _with_ their cookbooks](https://github.com/sethvargo/chefspec/tree/unify_matchers#packaging-lwrp-matchers) at distribution time.
 2. New features without accompanying unit tests, cucumber tests, and documentation.
 
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ RSpec.configure do |config|
 end
 ```
 
-Values specified at the initalization of the `Runner` merge and take precedence over the global settings:
+Values specified at the initialization of the `Runner` merge and take precedence over the global settings:
 
 ```ruby
 # Override only the operating system version (platform is still "ubuntu" from above)
@@ -213,7 +213,7 @@ expect(chef_run).to render_file('/etc/foo').with_content('This is content')
 expect(chef_run).to render_file('/etc/foo').with_content(/regex works too.+/)
 ```
 
-Additionally, it is possible to assert which [Chef phase of execution](http://docs.opscode.com/essentials_nodes_chef_run.html) a resouce is created. Given a resource that is installed at compile time using `run_action`:
+Additionally, it is possible to assert which [Chef phase of execution](http://docs.opscode.com/essentials_nodes_chef_run.html) a resource is created. Given a resource that is installed at compile time using `run_action`:
 
 ```ruby
 package('apache2').run_action(:install)
@@ -225,7 +225,7 @@ You can assert that this package is installed during runtime using the `.at_comp
 expect(chef_run).to install_package('apache2').at_compile_time
 ```
 
-Simiarly, you can assert that a resource is executed during convergence time:
+Similarly, you can assert that a resource is executed during convergence time:
 
 ```ruby
 expect(chef_run).to install_package('apache2').at_converge_time
@@ -537,7 +537,7 @@ Please use this as a _temporary_ solution. Consider sending a Pull Request to th
 
 Expecting Exceptions
 --------------------
-In Chef 11, custom formatters were introduced and ChefSpec uses a custom formatter to supress Chef Client output. In the event of a convergence failure, ChefSpec will output the error message from the run to help you debug:
+In Chef 11, custom formatters were introduced and ChefSpec uses a custom formatter to suppress Chef Client output. In the event of a convergence failure, ChefSpec will output the error message from the run to help you debug:
 
 ```text
 ================================================================================
@@ -687,7 +687,7 @@ Development
         $ git checkout -b my_bug_fix
 
 4. **Write tests**
-5. Make your changes/patches/fixes, committing appropiately
+5. Make your changes/patches/fixes, committing appropriately
 6. Run the tests: `bundle exec rake`
 7. Push your changes to GitHub
 8. Open a Pull Request


### PR DESCRIPTION
Removes all references to `ChefSpec::ChefRunner` from the README and fixes a bunch of typos.
