### PR TITLE
Allow a block to be executed after cookbook compile but before converge

### DIFF
--- a/lib/chefspec/runner.rb
+++ b/lib/chefspec/runner.rb
@@ -153,6 +153,9 @@ module ChefSpec
       # Setup the run_context
       @run_context = client.setup_run_context
 
+      # Allow stubbing/mocking after the cookbook has been compiled but before the converge
+      yield if block_given?
+
       @converging = true
       @client.converge(@run_context)
       self


### PR DESCRIPTION
This will allow users to pass a block to the converge method specifying mocks/stubs and not have them whacked by chef when it loads the cookbook.  See issue #253 for more info. Pull request coming.
