### PR TITLE
Don't include the deprecations module by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,16 @@ Important Notes
 - **Each resource matcher is self-documented using [Yard](http://rubydoc.info/github/sethvargo/chefspec) and has a corresponding aruba test from the [examples directory](https://github.com/sethvargo/chefspec/tree/master/examples).**
 - **ChefSpec 3.0 requires Ruby 1.9 or higher!**
 
+If you are migrating from ChefSpec v2.0.0, you should require the deprecations module after requiring `chefspec`:
+
+```ruby
+# spec_helper.rb
+require 'chefspec'
+require 'chefspec/deprecations'
+```
+
+After you have converted your specs, you can safely remove the deprecations module.
+
 
 Writing a Cookbook Example
 --------------------------

--- a/lib/chefspec.rb
+++ b/lib/chefspec.rb
@@ -30,7 +30,3 @@ require_relative 'chefspec/renderer'
 require_relative 'chefspec/rspec'
 require_relative 'chefspec/runner'
 require_relative 'chefspec/version'
-
-# Load deprecations module last, so it can monkey patch and print out nasty
-# deprecation warnings for us :)
-require_relative 'chefspec/deprecations'

--- a/lib/chefspec/deprecations.rb
+++ b/lib/chefspec/deprecations.rb
@@ -50,6 +50,9 @@ module ChefSpec
 end
 
 module ChefSpec::API
+  #
+  # @todo Remove in v4.0.0
+  #
   module DeprecatedMatchers
     def be_owned_by(user, group)
       deprecated "The `be_owned_by` matcher is deprecated. Please use:" \


### PR DESCRIPTION
In the next release of ChefSpec, the deprecations module will not be required by default. Because the module is a monkey-patch on top of existing monkey patches, it weighs a significant overhead loading it on each run. It also provides no benefit to new users of ChefSpec or users who have already converted their code to use the ChefSpec 3 matchers.

The deprecations module still exists, but it will no longer be included by default. Users still wishing to switch from ChefSpec 2.x can manually require the module, as outlined in the README.

This module will be completely removed in ChefSpec 4.
