### PR TITLE
Add resource reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,40 @@ describe 'example::default' do
 end
 ```
 
+Reporting
+---------
+ChefSpec attempts to generate a report of resources read over resources tested. Please note, this feature is currently in beta phases and may not be 100% accurate. That being said, it's currently the only code coverage tool available for Chef recipes.
+
+To generate the coverage report, add the following the the **very end** of your `spec_helper.rb`:
+
+```ruby
+# Existing things...
+
+at_exit { ChefSpec::Coverage.report! }
+```
+
+By default, that method will output helpful information to standard out:
+
+```text
+ChefSpec Coverage report generated at '.coverage/results.json':
+
+  Total Resources:   6
+  Touched Resources: 1
+  Touch Coverage:    16.67%
+
+Untouched Resources:
+
+  package[git]: bacon/recipes/default.rb:2
+  package[build-essential]: bacon/recipes/default.rb:3
+  package[apache2]: bacon/recipes/default.rb:4
+  package[libvrt]: bacon/recipes/default.rb:5
+  package[core]: bacon/recipes/default.rb:6
+```
+
+It also outputs a machine-parsable JSON file at `.coverage/results.json`. This file can be read by your CI server to determine changes in code coverage. We recommend adding the `.coverage` directory to your `.gitignore` to avoid committing it to git.
+
+You can configure both the announcing behavior and JSON file. Please see the YARD documentaion for more information.
+
 
 Mocking Out Environments
 ------------------------

--- a/lib/chefspec.rb
+++ b/lib/chefspec.rb
@@ -21,6 +21,7 @@ require_relative 'chefspec/stubs/search_registry'
 require_relative 'chefspec/stubs/search_stub'
 
 require_relative 'chefspec/api'
+require_relative 'chefspec/coverage'
 require_relative 'chefspec/errors'
 require_relative 'chefspec/expect_exception'
 require_relative 'chefspec/formatter'

--- a/lib/chefspec/coverage.rb
+++ b/lib/chefspec/coverage.rb
@@ -1,0 +1,144 @@
+module ChefSpec
+  class Coverage
+    class << self
+      extend Forwardable
+      def_delegators :instance, :add, :cover!, :report!
+    end
+
+    include Singleton
+
+    #
+    # Create a new coverage object singleton.
+    #
+    def initialize
+      @collection = {}
+    end
+
+    #
+    # Add a resource to the resource collection.
+    #
+    # @param [Chef::Resource] resource
+    #
+    def add(resource)
+      @collection[resource.to_s] = ResourceWrapper.new(resource)
+    end
+
+    #
+    # Called when a resource is matched to indicate it has been tested.
+    #
+    # @param [Chef::Resource] resource
+    #
+    def cover!(resource)
+      if wrapper = find(resource)
+        wrapper.touch!
+      end
+    end
+
+    #
+    # Generate a coverage report. This report **must** be generated +at_exit+
+    # or else the entire resource collection may not be complete!
+    #
+    # @example Generating a report
+    #
+    #   at_exit { ChefSpec::Coverage.report! }
+    #
+    # @example Generating a custom report without announcing
+    #
+    #   at_exit { ChefSpec::Coverage.report!('/custom/path', false) }
+    #
+    #
+    # @param [String] output
+    #   the path to output the report on disk (default: '.coverage/results.json')
+    # @param [Boolean] announce
+    #   print the results to standard out
+    #
+    def report!(output = '.coverage/results.json', announce = true)
+      report = {}
+
+      report[:total] = @collection.size
+      report[:touched] = @collection.count { |_, resource| resource.touched? }
+      report[:untouched] = report[:total] - report[:touched]
+      report[:coverage] = ((report[:touched].to_f/report[:total].to_f)*100).round(2)
+
+      report[:detailed] = Hash[*@collection.map do |name, wrapper|
+        [name, wrapper.to_hash]
+      end.flatten]
+
+      output = File.expand_path(output)
+      FileUtils.mkdir_p(File.dirname(output))
+      File.open(File.join(output), 'w') do |f|
+        f.write(JSON.pretty_generate(report) + "\n")
+      end
+
+      if announce
+        puts <<-EOH.gsub(/^ {10}/, '')
+
+          WARNING: ChefSpec Coverage reporting is in beta. Please use with caution.
+
+          ChefSpec Coverage report generated at '#{output}':
+
+            Total Resources:   #{report[:total]}
+            Touched Resources: #{report[:touched]}
+            Touch Coverage:    #{report[:coverage]}%
+
+          Untouched Resources:
+
+          #{
+            report[:detailed]
+              .select { |_, resource| !resource[:touched] }
+              .sort_by { |_, resource| [resource[:source][:file], resource[:source][:line]] }
+              .map do |name, resource|
+                "  #{name} #{resource[:source][:file]}:#{resource[:source][:line]}"
+              end
+              .flatten
+              .join("\n")
+          }
+
+        EOH
+      end
+    end
+
+    private
+
+      def find(resource)
+        @collection[resource.to_s]
+      end
+
+      class ResourceWrapper
+        attr_reader :resource
+
+        def initialize(resource = nil)
+          @resource = resource
+        end
+
+        def to_s
+          @resource.to_s
+        end
+
+        def source
+          return {} unless @resource.source_line
+          file, line, *_ = @resource.source_line.split(':')
+
+          {
+            file: file,
+            line: line.to_i,
+          }
+        end
+
+        def to_hash
+          {
+            source: source,
+            touched: touched?,
+          }
+        end
+
+        def touch!
+          @touched = true
+        end
+
+        def touched?
+          !!@touched
+        end
+      end
+  end
+end

--- a/lib/chefspec/extensions/chef/resource.rb
+++ b/lib/chefspec/extensions/chef/resource.rb
@@ -14,6 +14,8 @@ class Chef::Resource
 
     Chef::Log.info("Processing #{self} action #{action} (#{defined_at})")
 
+    ChefSpec::Coverage.add(self)
+
     unless should_skip?(action)
       if node.runner.step_into?(self)
         instance_eval { @not_if = []; @only_if = [] }

--- a/lib/chefspec/matchers/resource_matcher.rb
+++ b/lib/chefspec/matchers/resource_matcher.rb
@@ -43,6 +43,7 @@ module ChefSpec::Matchers
       @runner = runner
 
       if resource
+        ChefSpec::Coverage.cover!(resource)
         resource.performed_action?(@expected_action) && unmatched_parameters.empty? && correct_phase?
       else
         false


### PR DESCRIPTION
This is the first pass at adding resource reporting to ChefSpec. It's pretty raw, kinda ugly, and really makes me wish there was a better way to do this. 

In the future, this could be expanded to generate a pretty HTML report, but generating JSON is "good enough for now", and hopefully a good open-source advocate will make this better.

/cc @ranjib 
