### PR TITLE
Make ChefSpec::Cacher threadsafe

### DIFF
--- a/lib/chefspec/cacher.rb
+++ b/lib/chefspec/cacher.rb
@@ -24,8 +24,6 @@ module ChefSpec
   #   Finally, celebrate!
   #
   # @warn
-  #   This strategy is _not_ threadsafe!
-  # @warn
   #   This strategy is only recommended for advanced users, as it makes
   #   stubbing slightly more difficult and indirect!
   #
@@ -40,7 +38,9 @@ module ChefSpec
 
       define_method(name) do
         key = [location, name.to_s].join('.')
-        ObjectSpace.define_finalizer( Thread.current, FINALIZER ) unless @@cache.has_key? Thread.current.object_id
+        unless @@cache.has_key?(Thread.current.object_id)
+          ObjectSpace.define_finalizer(Thread.current, FINALIZER)
+        end
         @@cache[Thread.current.object_id] ||= {}
         @@cache[Thread.current.object_id][key] ||= instance_eval(&block)
       end

--- a/spec/unit/cacher_spec.rb
+++ b/spec/unit/cacher_spec.rb
@@ -32,10 +32,10 @@ describe ChefSpec::Cacher do
     end
     
     context 'when multithreaded environment' do
-      it "is thread safe" do
+      it 'is thread safe' do
         (1..2).each do |n|
           Thread.new do
-            klass.cached(:chef_run){ n }
+            klass.cached(:chef_run) { n }
             expect(klass.new.chef_run).to eq(n)
           end.join
         end


### PR DESCRIPTION
Unfortunately could not test that the `FINALIZER` will delete the Thread cache. I tried this, but didn't work:

``` ruby
it 'deletes thread data when thread finished' do
  Thread.new do
    runner = double(:runner)
    klass.cached(:chef_run) { runner }
    klass.new.chef_run
    expect(cache).not_to be_empty
  end.join

  expect(cache).to be_empty
end
```
