### PR TITLE
Try to find stub nodes that are usable

### DIFF
--- a/examples/server/recipes/node.rb
+++ b/examples/server/recipes/node.rb
@@ -1,10 +1,16 @@
-nodesearch = search(:node, '*:*')
-nodes = nodesearch.map(&:to_s).sort.join(', ')
+nodes = search(:node, '*:*')
+nodes = nodes.map(&:to_s).sort.join(', ')
 
 log 'nodes' do
   message nodes
 end
 
-log 'nodenames' do
-  message nodesearch.map{|n| '"' + n[:id].to_s + ',' + n[:fqdn].to_s + ',' + n['fqdn'].to_s + '"'}.sort.join(', ') #each { |n| n[:fqdn].to_s }
+
+examplenodes = []
+search(:node, 'fqdn:*.example.com').each do |n|
+  examplenodes << n['fqdn']
+end
+
+log 'examplenodes' do
+  message examplenodes.join(', ')
 end

--- a/examples/server/spec/node_spec.rb
+++ b/examples/server/spec/node_spec.rb
@@ -2,34 +2,56 @@ require 'chefspec'
 load 'chefspec/server.rb'
 
 describe 'server::node' do
-  let(:chef_run) { ChefSpec::Runner.new.converge(described_recipe) }
-  before do
-    ChefSpec::Server.create_node(
-      'bacon',
-      stub_node(
-        'bacon',
-        platform: 'ubuntu',
-        version: '12.04',
-        ohai: { fqdn:'bacon.example.com' }
+
+  context 'one simple extra node to be found,' do
+
+    let(:chef_run) { ChefSpec::Runner.new.converge(described_recipe) }
+
+    it 'do not raise an exception' do
+      expect { chef_run }.to_not raise_error
+    end
+
+    it 'search the Chef Server for nodes' do
+      ChefSpec::Server.create_node('bacon', { name: 'bacon'})
+
+      expect(chef_run).to write_log('nodes')
+        .with_message('node[bacon], node[chefspec]')
+    end
+
+  end
+  context 'two additional nodes with fauxhai-data,' do
+
+    let(:chef_run) { ChefSpec::Runner.new.converge(described_recipe) }
+
+    before do
+      ChefSpec::Server.create_node(
+        'ham',
+        stub_node(
+          'ham',
+          platform: 'debian',
+          version: '7.1',
+          ohai: { fqdn:'ham.example.com' }
+        )
       )
-    )
-  end
+      ChefSpec::Server.create_node(
+        'bacon',
+        stub_node(
+          'bacon',
+          platform: 'ubuntu',
+          version: '12.04',
+          ohai: { fqdn:'bacon.example.com' }
+        )
+      )
+    end
 
-  it 'does not raise an exception' do
-    expect { chef_run }.to_not raise_error
-  end
+    it 'search for all nodes' do
+      expect(chef_run).to write_log('nodes')
+        .with_message('node[bacon], node[chefspec], node[ham]')
+    end
 
-  it 'searches the Chef Server for nodes' do
-    expect(chef_run).to write_log('nodes')
-      .with_message('node[bacon], node[chefspec]')
-  end
-
-  it 'searches for nodes with fqdn chefspec.local (the own client during chefspec-run)' do
-    expect(chef_run).to write_log('nodenames')
-      .with_message(/chefspec.local/)
-  end
-  it 'searches for nodes with fqdn bacon.example.com' do
-    expect(chef_run).to write_log('nodenames')
-      .with_message(/bacon.example.com/)
+    it 'search for all nodes with domain-part .example.com' do
+      expect(chef_run).to write_log('examplenodes')
+        .with_message('bacon.example.com, ham.example.com')
+    end
   end
 end


### PR DESCRIPTION
I want to use some simulated nodes in tests for the munin-cookbook. But I can't seem to stub out fake nodes for the search that have things like 'fqdn' or 'ipaddress'.

So maybe just try to extend the example here? What am I doing wrong?
