### PR TITLE
Raise an error when cookbook_path can't be determined.

### DIFF
--- a/lib/chefspec/runner.rb
+++ b/lib/chefspec/runner.rb
@@ -299,6 +299,9 @@ module ChefSpec
       #
       def calling_cookbook_path(kaller)
         calling_spec = kaller.find { |line| line =~ /\/spec/ }
+        if calling_spec.nil?
+          raise Error, "Can't find cookbook_path. (You should put spec files under 'spec' directory or set RSpec.configuration.cookbook_path)"
+        end
         bits = calling_spec.split(':', 2).first.split(File::SEPARATOR)
         spec_dir = bits.index('spec') || 0
 


### PR DESCRIPTION
Without this patch:

```
  1) example::default installs foo
     Failure/Error: let(:chef_run) { ChefSpec::Runner.new.converge(described_recipe) }
     NoMethodError:
       undefined method `split' for nil:NilClass
     # ./foo_spec.rb:4:in `new'
     # ./foo_spec.rb:4:in `block (2 levels) in <top (required)>'
     # ./foo_spec.rb:7:in `block (2 levels) in <top (required)>'
```

With this patch:

```
  1) example::default installs foo
     Failure/Error: let(:chef_run) { ChefSpec::Runner.new.converge(described_recipe) }
     ChefSpec::Error:
       Can't find cookbook_path. (You should put spec files under 'spec' directory or set RSpec.configuration.cookbook_path)
     # /Users/ryota/code/github/sethvargo/chefspec/lib/chefspec/runner.rb:303:in `calling_cookbook_path'
     # /Users/ryota/code/github/sethvargo/chefspec/lib/chefspec/runner.rb:67:in `initialize'
     # ./foo_spec.rb:4:in `new'
     # ./foo_spec.rb:4:in `block (2 levels) in <top (required)>'
     # ./foo_spec.rb:7:in `block (2 levels) in <top (required)>'
```
