### PR TITLE
Allow filters to restrict coverage report only from certain directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,6 +522,12 @@ It also outputs a machine-parsable JSON file at `.coverage/results.json`. This f
 
 You can configure both the announcing behavior and JSON file. Please see the YARD documentaion for more information.
 
+If you want to restrict coverage reporting only against certain cookbook directories, you can do it using filters. For example, to include only the site-cookbooks directory for coverage reporting, add the following line in your ```spec/spec_helper.rb```
+
+```ruby
+ ChefSpec::Coverage.filters << File.expand_path('../../site-cookbooks', __FILE__)
+```
+
 
 Mocking Out Environments
 ------------------------

--- a/lib/chefspec/coverage.rb
+++ b/lib/chefspec/coverage.rb
@@ -1,8 +1,11 @@
 module ChefSpec
   class Coverage
+
+    attr_accessor :filters
+
     class << self
       extend Forwardable
-      def_delegators :instance, :add, :cover!, :report!
+      def_delegators :instance, :add, :cover!, :report!, :filters
     end
 
     include Singleton
@@ -12,6 +15,7 @@ module ChefSpec
     #
     def initialize
       @collection = {}
+      @filters = []
     end
 
     #
@@ -20,7 +24,7 @@ module ChefSpec
     # @param [Chef::Resource] resource
     #
     def add(resource)
-      @collection[resource.to_s] = ResourceWrapper.new(resource)
+      @collection[resource.to_s] = ResourceWrapper.new(resource) if filtered?(resource)
     end
 
     #
@@ -29,9 +33,18 @@ module ChefSpec
     # @param [Chef::Resource] resource
     #
     def cover!(resource)
-      if wrapper = find(resource)
+      if filtered?(resource) and (wrapper = find(resource))
         wrapper.touch!
       end
+    end
+
+    #
+    # Called to check if a resource belongs to a cookbook from the specified directories
+    #
+    # @param [Chef::Resource] resource
+    #
+    def filtered?(resource)
+      filters.empty? or filters.any?{|f| resource.source_line =~/^#{f}/}
     end
 
     #


### PR DESCRIPTION
I want to get coverage report only from certain directories (site-cookbooks) currently `ChefSpec::Coverage.report!` calculates coverage against all vendored cookbooks, which lowers our overall coverage, as well as provides report about cookbooks that we dont maintain (pulled down via berks)
