### PR TITLE
Update default_spec.rb

### DIFF
--- a/examples/attributes/spec/default_spec.rb
+++ b/examples/attributes/spec/default_spec.rb
@@ -10,7 +10,7 @@ describe 'attributes::default' do
 
   it 'uses the overridden node attribute' do
     expect(chef_run).to write_log('The new message is here')
-    expect(chef_run).to_not write_log('The old message is here')
+    expect(chef_run).to_not write_log('This is the default message')
   end
 
   it 'uses the overridden ohai attribute' do


### PR DESCRIPTION
Based on the default message provided in ../attributes/default.rb, shouldn't line 13 of this spec be corrected to match the actual default message that should be over-ridden on line 7?

Or did I miss something obvious?
