### PR TITLE
Add virtual recipe support

### DIFF
--- a/lib/chefspec.rb
+++ b/lib/chefspec.rb
@@ -6,6 +6,7 @@ require_relative 'chefspec/extensions/chef/data_query'
 require_relative 'chefspec/extensions/chef/lwrp_base'
 require_relative 'chefspec/extensions/chef/resource'
 require_relative 'chefspec/extensions/chef/securable'
+require_relative 'chefspec/extensions/chef/cookbook_version'
 
 require_relative 'chefspec/mixins/normalize'
 

--- a/lib/chefspec/extensions/chef/cookbook_version.rb
+++ b/lib/chefspec/extensions/chef/cookbook_version.rb
@@ -1,0 +1,17 @@
+class Chef::CookbookVersion
+
+  alias_method :load_recipe_without_inline_recipe, :load_recipe
+
+  def load_recipe(recipe_name, run_context)
+    runner = run_context.node.runner
+    recipe_body = runner.virtual_recipes["#{name}::#{recipe_name}"]
+    if recipe_body
+      recipe = Chef::Recipe.new(name, recipe_name, run_context)
+      recipe.instance_eval(&recipe_body)
+      return recipe
+    else
+      return load_recipe_without_inline_recipe(recipe_name, run_context)
+    end
+  end
+
+end


### PR DESCRIPTION
This patch enables the creation of inlined virtual recipes. It is useful to test definitions.

```
runner = ChefSpec::Runner.new    
runner.define_recipe('cookbook::virtual_recipe') do
  mydefinition 'test' do
    ...
  end    
end

runner.converge('cookbook::virtual_recipe')
```

or

```
runner = ChefSpec::Runner.new    
runner.converge_virtual_recipe('cookbook') do
  mydefinition 'test' do
    ...
  end    
end
```
