### PR TITLE
Setting the name on arbitrary objects looks like trouble

### DIFF
--- a/examples/server/spec/node_spec.rb
+++ b/examples/server/spec/node_spec.rb
@@ -31,7 +31,7 @@ describe 'server::node' do
           platform: 'debian',
           version: '7.1',
           ohai: { fqdn:'ham.example.com' }
-        )
+        ).to_hash
       )
       ChefSpec::Server.create_node(
         'bacon',
@@ -39,8 +39,8 @@ describe 'server::node' do
           'bacon',
           platform: 'ubuntu',
           version: '12.04',
-          ohai: { fqdn:'bacon.example.com' }
-        )
+          ohai: { 'fqdn' => 'bacon.example.com' }
+        ).to_hash
       )
     end
 

--- a/lib/chefspec/server.rb
+++ b/lib/chefspec/server.rb
@@ -101,7 +101,7 @@ module ChefSpec
         def create_#{method}(name, data = {})
           unless '#{key}' == 'data'
             # Automatically set the "name" if no explicit one was given
-            #data[:name] ||= name
+            data[:name] ||= name
 
             # Convert it to JSON
             data = JSON.fast_generate(data)


### PR DESCRIPTION
When setting the name-attribute on nodes (like when stubbing nodes for search/chef-zero), it complains about a missing precedence. But when setting a precedence by using `data.set[:name] ||= name` it all fails when its not a complete fauxhai-node that is stubbed. Why not do without setting the name attribute?
