### PR TITLE
Skip coverage calculation when total number of resources is 0

### DIFF
--- a/lib/chefspec/coverage.rb
+++ b/lib/chefspec/coverage.rb
@@ -74,6 +74,12 @@ module ChefSpec
       report = {}
 
       report[:total] = @collection.size
+
+      if report[:total] == 0
+        puts "No resources found, skipping coverage calculation"
+        return
+      end
+
       report[:touched] = @collection.count { |_, resource| resource.touched? }
       report[:untouched] = report[:total] - report[:touched]
       report[:coverage] = ((report[:touched].to_f/report[:total].to_f)*100).round(2)


### PR DESCRIPTION
coverage calculation throws `NaN` (not a number) exception when total number of resources is 0, (it comes from JSON generate). Since we have specs for knife plugins and other libs which does not involved recipes (hence no resources) but the `spec_helper` invokes chefspec coverage at_exit which fails the build.
