### PR TITLE
Add README and others into gemspec

### DIFF
--- a/chefspec.gemspec
+++ b/chefspec.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.homepage     = 'http://code.sethvargo.com/chefspec'
   s.license      = 'MIT'
   s.require_path = 'lib'
-  s.files        = Dir['lib/**/*.rb', 'locales/**/*.yml']
+  s.files        = ['README.md', 'LICENSE', 'CHANGELOG.md'] + Dir['lib/**/*.rb', 'locales/**/*.yml']
 
   # ChefSpec requires Ruby 1.9+
   s.required_ruby_version = '>= 1.9'


### PR DESCRIPTION
I noticed that the README.md file was missing from the auto-generated docs at http://rubydoc.info/gems/chefspec/frames - I'm pretty sure this is what's necessary to correct this. rubydoc.info lands people on the README if it's present, and other files are available from the files tab in that link.

I also figured that the license and changelog deserved to be packaged along with the distributed gem
