### PR TITLE
Update gemspec

### DIFF
--- a/chefspec.gemspec
+++ b/chefspec.gemspec
@@ -1,22 +1,27 @@
 lib = File.expand_path('../lib/', __FILE__)
 $:.unshift lib unless $:.include?(lib)
-
 require 'chefspec/version'
+
 Gem::Specification.new do |s|
-  s.name         = 'chefspec'
-  s.version      = ChefSpec::VERSION
-  s.description  = 'ChefSpec is a unit testing and resource coverage ' \
-                   '(code coverage) framework for testing Chef cookbooks ' \
-                   'ChefSpec makes it easy to write examples and get fast ' \
-                   'feedback on cookbook changes without the need for ' \
-                   'virtual machines or cloud servers.'
-  s.summary      = 'Write RSpec examples and generate coverage reports for ' \
-                   'Chef recipes!'
-  s.authors      = ['Andrew Crump', 'Seth Vargo']
-  s.homepage     = 'http://code.sethvargo.com/chefspec'
-  s.license      = 'MIT'
-  s.require_path = 'lib'
-  s.files        = Dir['lib/**/*.rb', 'locales/**/*.yml']
+  s.name          = 'chefspec'
+  s.version       = ChefSpec::VERSION
+  s.authors       = ['Andrew Crump', 'Seth Vargo']
+  s.email         = ['andrew.crump@ieee.org', 'sethvargo@gmail.com']
+  s.summary       = 'Write RSpec examples and generate coverage reports for ' \
+                    'Chef recipes!'
+  s.description   = 'ChefSpec is a unit testing and resource coverage ' \
+                    '(code coverage) framework for testing Chef cookbooks ' \
+                    'ChefSpec makes it easy to write examples and get fast ' \
+                    'feedback on cookbook changes without the need for ' \
+                    'virtual machines or cloud servers.'
+  s.homepage      = 'http://code.sethvargo.com/chefspec'
+  s.license       = 'MIT'
+
+  # Packaging
+  s.files         = `git ls-files`.split($/)
+  s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  s.test_files    = s.files.grep(%r{^(test|spec|features)/})
+  s.require_paths = ['lib']
 
   # ChefSpec requires Ruby 1.9+
   s.required_ruby_version = '>= 1.9'


### PR DESCRIPTION
This commit updates the gemspec to use `git ls-files` instead of Dir globbing to calculate what files are packaged with the gem.
