### PR TITLE
Fix the monkey-patch to the raise_error matcher

### DIFF
--- a/lib/chefspec/expect_exception.rb
+++ b/lib/chefspec/expect_exception.rb
@@ -3,7 +3,11 @@ class RSpec::Matchers::BuiltIn::RaiseError
     attr_accessor :last_run
   end
 
-  attr_reader :expected_error, :expected_message
+  attr_reader :expected_message
+
+  def last_error_for_chefspec 
+    @expected_error
+  end
 
   alias_method :old_matches?, :matches?
   def matches?(*args)
@@ -28,8 +32,8 @@ module ChefSpec
     private
 
     def exception_matched?
-      @formatter_exception == @matcher.expected_error ||
-      @matcher.expected_error === @formatter_exception
+      @formatter_exception == @matcher.last_error_for_chefspec ||
+      @matcher.last_error_for_chefspec === @formatter_exception
     end
 
     def message_matched?

--- a/spec/unit/expect_exception_spec.rb
+++ b/spec/unit/expect_exception_spec.rb
@@ -14,7 +14,7 @@ describe ChefSpec::ExpectException do
     subject { described_class.new(RuntimeError) }
 
     it 'does not match' do
-      last_error = double('last error', expected_error: ArgumentError)
+      last_error = double('last error', last_error_for_chefspec: ArgumentError)
       RSpec::Matchers::BuiltIn::RaiseError.stub(:last_run).and_return(last_error)
       expect(subject.expected?).to be_false
     end
@@ -24,7 +24,7 @@ describe ChefSpec::ExpectException do
     subject { described_class.new(RuntimeError) }
 
     it 'does not match' do
-      last_error = double('last error', expected_error: RuntimeError)
+      last_error = double('last error', last_error_for_chefspec: RuntimeError)
       RSpec::Matchers::BuiltIn::RaiseError.stub(:last_run).and_return(last_error)
       expect(subject.expected?).to be_true
     end


### PR DESCRIPTION
I don't really like the non-rubyish `#get_expected_error` method name (suggestions?), but this adds the direct access to the `@expected_error` object that chefspec is looking for, without breaking the `raise_error` matcher's functionality. 

I tried first to just make the original `RaiseError#expected_error` method available publicly (it is a private method in `RaiseError`), but RSpec only returns a mutated form of `@expected_error` from that method, which breaks `ChefSpec's ExpectException` when it tries to do its comparisons.

So, in the end, the most harmless way to get at what `ExpectException` needs to do its job is to make another method to get at the `@expected_error object`.

Doing things this way fixes #339.  I did not add a regression for that specific issue because anything I thought of doing felt like testing RSpec. ChefSpec just had to stop stomping on RSpec's method. If a regression is still wanted, I'm open to suggestions.
