### PR TITLE
Adding read accessor for @tmpdir in ChefSpec::Berkshelf

### DIFF
--- a/lib/chefspec/berkshelf.rb
+++ b/lib/chefspec/berkshelf.rb
@@ -11,6 +11,8 @@ module ChefSpec
       def_delegators :instance, :setup!, :teardown!
     end
 
+    attr_reader :tmpdir
+
     include Singleton
 
     def initialize


### PR DESCRIPTION
This commit adds a method to access the tmpdir variable in ChefSpec::Berkshelf.

ChefSpec::Berkshelf stores all it's cookbooks in a tmp directory.
This makes the use of `ChefSpec::Coverage.filters` impossible when Berkshelf is used with ChefSpec.

Adding this method allows for the filtering of Berkshelf cookbooks in the coverage report.
