### PR TITLE
Update README.md with corrected stub_node example

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,7 +386,8 @@ You may also be interested in the `stub_node` macro, which will create a new `Ch
 
 ```ruby
 www = stub_node('example.com', platform: 'ubuntu', version: '12.04') do |node|
-        node.set['fqdn'] = 'www1.example.com'
+        node.automatic['fqdn'] = 'www1.example.com'
+        node.set['my_attribute'] = 'my_value'
       end
       
 # `www` is now a local Chef::Node object you can use in your test. To push this


### PR DESCRIPTION
Updated README.me with working stub_node example.

Calling stub_node without the name option results in an exception being thrown 

```
Chef::Exceptions::ValidationFailed:
       Option name must be a kind of String! 
```

Attempting to directly update a node object without using .set, .normal, etc leads to the error

```
Chef::Exceptions::ImmutableAttributeModification:
       Node attributes are read-only when you do not specify which precedence level to set. To set an attribute use code like `node.default["key"] = "value"'
```
