### PR TITLE
render_file_matcher: support arbitrary RSpec matchers

### DIFF
--- a/examples/render_file/spec/default_spec.rb
+++ b/examples/render_file/spec/default_spec.rb
@@ -18,6 +18,15 @@ describe 'render_file::default' do
       expect(chef_run).to render_file('/tmp/file').with_content(/^This(.+)$/)
       expect(chef_run).to_not render_file('/tmp/file').with_content(/^Not(.+)$/)
     end
+
+    it 'renders the file with content matching arbitrary matcher' do
+      expect(chef_run).to render_file('/tmp/file').with_content(
+        start_with('This')
+      )
+      expect(chef_run).to_not render_file('/tmp/file').with_content(
+        end_with('not')
+      )
+    end
   end
 
   context 'cookbook_file' do
@@ -35,6 +44,15 @@ describe 'render_file::default' do
       expect(chef_run).to render_file('/tmp/cookbook_file').with_content(/^This(.+)$/)
       expect(chef_run).to_not render_file('/tmp/cookbook_file').with_content(/^Not(.+)$/)
     end
+
+    it 'renders the file with content matching arbitrary matcher' do
+      expect(chef_run).to render_file('/tmp/cookbook_file').with_content(
+        start_with('This')
+      )
+      expect(chef_run).to_not render_file('/tmp/cookbook_file').with_content(
+        end_with('not')
+      )
+    end
   end
 
   context 'template' do
@@ -51,6 +69,15 @@ describe 'render_file::default' do
     it 'renders the file with matching content' do
       expect(chef_run).to render_file('/tmp/template').with_content(/^This(.+)$/)
       expect(chef_run).to_not render_file('/tmp/template').with_content(/^Not(.+)$/)
+    end
+
+    it 'renders the file with content matching arbitrary matcher' do
+      expect(chef_run).to render_file('/tmp/template').with_content(
+        start_with('This')
+      )
+      expect(chef_run).to_not render_file('/tmp/template').with_content(
+        end_with('not')
+      )
     end
   end
 

--- a/lib/chefspec/api/render_file.rb
+++ b/lib/chefspec/api/render_file.rb
@@ -16,6 +16,9 @@ module ChefSpec::API
     # @example Assert a template is rendered with matching content
     #   expect(template).to render_file('/etc/foo').with_content(/^This(.+)$/)
     #
+    # @example Assert a template is rendered with content matching any RSpec matcher
+    #   expect(template).to render_file('/etc/foo').with_content(starts_with('This'))
+    #
     # @example Assert a partial path to a template is rendered with matching content
     #   expect(template).to render_file(/\/etc\/foo-(\d+)$/).with_content(/^This(.+)$/)
     #

--- a/lib/chefspec/matchers/render_file_matcher.rb
+++ b/lib/chefspec/matchers/render_file_matcher.rb
@@ -29,9 +29,9 @@ module ChefSpec::Matchers
     def failure_message_for_should
       message = %Q{expected Chef run to render "#{@path}"}
       if @expected_content
-        message << " with:"
+        message << " matching:"
         message << "\n\n"
-        message << @expected_content.to_s
+        message << expected_content_message
         message << "\n\n"
         message << "but got:"
         message << "\n\n"
@@ -44,9 +44,9 @@ module ChefSpec::Matchers
     def failure_message_for_should_not
       message = %Q{expected file "#{@path}"}
       if @expected_content
-        message << " with:"
+        message << " matching:"
         message << "\n\n"
-        message << @expected_content.to_s
+        message << expected_content_message
         message << "\n\n"
       end
       message << " to not be in Chef run"
@@ -54,6 +54,14 @@ module ChefSpec::Matchers
     end
 
     private
+
+    def expected_content_message
+      if RSpec::Matchers.is_a_matcher?(@expected_content) && @expected_content.respond_to?(:description)
+        @expected_content.description
+      else
+        @expected_content.to_s
+      end
+    end
 
     def resource
       @resource ||= @runner.find_resource(:cookbook_file, @path) ||
@@ -88,6 +96,8 @@ module ChefSpec::Matchers
 
       if @expected_content.is_a?(Regexp)
         @actual_content =~ @expected_content
+      elsif RSpec::Matchers.is_a_matcher?(@expected_content)
+        @expected_content.matches?(@actual_content)
       else
         @actual_content.include?(@expected_content)
       end


### PR DESCRIPTION
Non-line-based configuration files (XML, JSON) are very hard to test
with simple string inclusion or regular expressions. Empower the
`render_file_matcher` to validate a template's content against any
arbitrary RSpec matcher.

This allows external libraries to drop in support for, say, an XPath
matcher

```
expect(template).to render_file('/foo').with_content(
  xml_with_xpath("configuration/property[value='foo']")
)
```

without either a) cluttering up ChefSpec core or b) re-implementing the
logic of `render_file`.
