### PR TITLE
Make Berksfile path configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,11 +133,11 @@ Requiring this file will:
 - Download all the dependencies listed in your `Berksfile` into the temporary directory
 - Set ChefSpec's `cookbook_path` to the temporary directory
 
-**NOTE:** If you want to specify a custom `Berksfile` path, you can set `Rspec.config.berkshelf`.
+**NOTE:** If you want to specify a custom `Berksfile` path, you can set `Rspec.config.berksfile_path`.
 
 ```ruby
 RSpec.configure do |config|
-  config.berksfile = 'Berksfile.test'
+  config.berksfile_path = 'Berksfile.test'
 end
 ```
 

--- a/lib/chefspec/berkshelf.rb
+++ b/lib/chefspec/berkshelf.rb
@@ -15,14 +15,14 @@ module ChefSpec
 
     def initialize
       @tmpdir = Dir.mktmpdir
-      @berksfile = RSpec.configuration.berksfile || 'Berksfile'
+      @berksfile_path = RSpec.configuration.berksfile_path || 'Berksfile'
     end
 
     #
     # Setup and install the necessary dependencies in the temporary directory.
     #
     def setup!
-      berksfile = ::Berkshelf::Berksfile.from_file(@berksfile)
+      berksfile = ::Berkshelf::Berksfile.from_file(@berksfile_path)
 
       # Grab a handle to tmpdir, since Berkshelf 2 modifies it a bit
       tmpdir = File.join(@tmpdir, 'cookbooks')

--- a/lib/chefspec/rspec.rb
+++ b/lib/chefspec/rspec.rb
@@ -15,5 +15,5 @@ RSpec.configure do |config|
   config.add_setting :path
   config.add_setting :platform
   config.add_setting :version
-  config.add_setting :berksfile
+  config.add_setting :berksfile_path
 end


### PR DESCRIPTION
Berkshelf provides the ability to use custom `Berksfile` paths with its `berks` command using the `--berksfile` flag. This pull request adds support for custom `Berksfile` paths to ChefSpec.

The use case I have involves two separate `Berksfile`s: one for installing cookbook dependencies on OpsWorks, and another that includes OpsWorks cookbooks for testing locally and in CI builds. Including OpsWorks cookbooks in the `Berksfile` used by OpsWorks could cause conflicts.

I tried to write tests, but it looked like `ChefSpec::Berkshelf` was untested and difficult to add tests for.
