### PR TITLE
Notifications are not obeying guards

### DIFF
--- a/examples/notifications/recipes/guard.rb
+++ b/examples/notifications/recipes/guard.rb
@@ -1,0 +1,23 @@
+template '/tmp/notifying_resource_with_not_if_true' do
+  not_if { true }
+  notifies :restart, 'service[receiving_resource]'
+end
+
+template '/tmp/notifying_resource_with_not_if_false' do
+  not_if { false }
+  notifies :restart, 'service[receiving_resource]'
+end
+
+template '/tmp/notifying_resource_with_only_if_false' do
+  only_if { false }
+  notifies :restart, 'service[receiving_resource]'
+end
+
+template '/tmp/notifying_resource_with_only_if_true' do
+  only_if { true }
+  notifies :restart, 'service[receiving_resource]'
+end
+
+service 'receiving_resource' do
+  action :nothing
+end

--- a/examples/notifications/spec/guard_spec.rb
+++ b/examples/notifications/spec/guard_spec.rb
@@ -1,0 +1,29 @@
+require 'chefspec'
+
+describe 'notifications::guard' do
+  let(:chef_run) { ChefSpec::Runner.new.converge(described_recipe) }
+
+  context 'using not_if' do
+    it 'does not send a notification to the service when guard condition true' do
+      template = chef_run.template('/tmp/notifying_resource_with_not_if_true')
+      expect(template).to_not notify('service[receiving_resource]')
+    end
+
+    it 'sends a notification to the service when guard condition false' do
+      template = chef_run.template('/tmp/notifying_resource_with_not_if_false')
+      expect(template).to notify('service[receiving_resource]')
+    end
+  end
+
+  context 'using only_if' do
+    it 'sends a notification to the service when guard condition true' do
+      template = chef_run.template('/tmp/notifying_resource_with_only_if_true')
+      expect(template).to notify('service[receiving_resource]')
+    end
+
+    it 'does not send a notification to the service when guard condition false' do
+      template = chef_run.template('/tmp/notifying_resource_with_only_if_false')
+      expect(template).to_not notify('service[receiving_resource]')
+    end
+  end
+end

--- a/features/notifications.feature
+++ b/features/notifications.feature
@@ -11,3 +11,4 @@ Feature: The notifications matcher
     | default     |
     | delayed     |
     | immediately |
+    | guard       |


### PR DESCRIPTION
I was trying to specify the behavior of notifications when guards were used, and found that notifications do not reflect whether the guard is applied or not. This seems to be in contrast with the behavior I'm seeing when running chef for real.

I don't know if this is even possibly related to chefspec - or rather chef itself - or if I've misunderstood how notifications with guards work. I found a few related issues, but none of them seemed to match this exactly, so I'm opening this one.

Anyway, I added a few failing examples to demonstrate my problem. Please advice on how to proceed.
