### PR TITLE
Allow resources to be matched by custom key/values

### DIFF
--- a/lib/chefspec/api/script.rb
+++ b/lib/chefspec/api/script.rb
@@ -40,6 +40,12 @@ module ChefSpec::API
 
     ChefSpec::Runner.define_runner_method :bash
 
+    def run_bash_code(code)
+      ChefSpec::Matchers::ResourceMatcherByKeyValue.new(:bash, :run, :code, code)
+    end
+
+    ChefSpec::Runner.define_runner_method :bash
+
     #
     # Assert that a +csh+ resource exists in the Chef run with the
     # action +:run+. Given a Chef Recipe that runs "command" using

--- a/lib/chefspec/matchers.rb
+++ b/lib/chefspec/matchers.rb
@@ -6,6 +6,7 @@ module ChefSpec
     require_relative 'matchers/notifications_matcher'
     require_relative 'matchers/render_file_matcher'
     require_relative 'matchers/resource_matcher'
+    require_relative 'matchers/resource_matcher_by_key_value'
     require_relative 'matchers/state_attrs_matcher'
     require_relative 'matchers/subscribes_matcher'
   end

--- a/lib/chefspec/matchers/resource_matcher_by_key_value.rb
+++ b/lib/chefspec/matchers/resource_matcher_by_key_value.rb
@@ -1,0 +1,28 @@
+module ChefSpec::Matchers
+  class ResourceMatcherByKeyValue < ChefSpec::Matchers::ResourceMatcher
+    def initialize(resource_name, expected_action, key, expected_value)
+      @resource_name     = resource_name
+      @expected_action   = expected_action
+      @key               = key
+      @expected_value    = expected_value
+    end
+    
+    def description
+      %Q{#{@expected_action} #{@resource_name} with #{@key} = "#{@expected_value}"}
+    end
+
+    private
+
+    #
+    # Find the resource in the Chef run by the given class name and
+    # resource key/value.
+    #
+    # @see ChefSpec::Runner#find_resource
+    #
+    # @return [Chef::Resource, nil]
+    #
+    def resource
+      @_resource ||= @runner.find_resource_by_key(@resource_name, @key, @expected_value)
+    end
+  end
+end

--- a/lib/chefspec/runner.rb
+++ b/lib/chefspec/runner.rb
@@ -180,6 +180,31 @@ module ChefSpec
     end
 
     #
+    # Find the resource with the declared type and resource key/value.
+    #
+    # @example Find bash resource by code `ls`
+    #   chef_run.find_resource_by(:bash, 'code', 'ls') #=> #<Chef::Resource::Bash>
+    #
+    #
+    # @param [Symbol] type
+    #   The type of resource (sometimes called `resource_name`) such as `file`
+    #   or `directory`.
+    # @param [String] key
+    #   The name of the attribute to lookup on the resource.
+    # @param [String, Regexp] value
+    #   The value of the 'key' attribute to lookup on the resource.
+    #
+    # @return [Chef::Resource, nil]
+    #   The matching resource, or nil if one is not found
+    #
+
+    def find_resource_by_key(type, key, value)
+      resource_collection.all_resources.find do |resource|
+        resource_name(resource) == type && value === resource.send(key)
+      end
+    end
+
+    #
     # Find the resource with the declared type.
     #
     # @example Find all template resources


### PR DESCRIPTION
Currently the only way to lookup resources is by their name or identity attribute. It would be nice to be able to lookup on any value of the resource (such as by the 'code' attribute on a script resource).

This is a spike. I'm interested to hear feedback about this approach. If this is agreeable, I will gladly clean this up, write tests, etc.
