### PR TITLE
Added 'report_untouched_recipes' coverage option.

### DIFF
--- a/templates/coverage/human.erb
+++ b/templates/coverage/human.erb
@@ -1,22 +1,37 @@
 
-<% if @total == 0 %>
-  No Chef resources found, skipping coverage calculation...
+<% if not @has_results %>
+  No Chef resources or recipes found, skipping coverage calculation...
 <% else %>
 ChefSpec Coverage report generated...
 
-  Total Resources:   <%= @total %>
-  Touched Resources: <%= @touched %>
-  Touch Coverage:    <%= @coverage %>%
+  Resource Total:    <%= @resource_total %>
+  Resources Touched: <%= @resource_touched %>
+  Resource Coverage: <%= @resource_coverage %>%
 
-<% if @untouched_resources.empty? %>
+<% if @recipe_reported %>
+  Recipe Total:      <%= @recipe_total %>
+  Recipes Touched:   <%= @recipe_touched %>
+  Recipe Coverage:   <%= @recipe_coverage %>%
+<% end %>
+
+<% if @full_coverage %>
 You are awesome and so is your test coverage! Have a fantastic day!
 
 <% else %>
+<% if @resource_untouched.any? %>
 Untouched Resources:
 
-<% @untouched_resources.each do |resource| %>
+<% @resource_untouched.each do |resource| %>
   <%= resource.to_s.ljust(32) %>   <%= resource.source_file %>:<%= resource.source_line %>
 <% end %>
+<% end %>
 
+<% if @recipe_reported and @recipe_untouched.any? %>
+Untouched Recipes:
+
+<% @recipe_untouched.each do |recipe| %>
+  <%= recipe.to_s %>
+<% end %>
+<% end %>
 <% end %>
 <% end %>


### PR DESCRIPTION
This displays a list of recipes that are not covered at all by the specs. To use this feature:

``` ruby
#Enable recipe reporting:
ChefSpec::Coverage.start! do
  report_untouched_recipes
end

#Disable recipe reporting:
ChefSpec::Coverage.start! do
  report_untouched_recipes false
end
```

The new coverage report looks like this:

```
ChefSpec Coverage report generated...

  Resource Total:    11
  Resources Touched: 10
  Resource Coverage: 90.91%

  Recipe Total:      5
  Recipes Touched:   3
  Recipe Coverage:   60.0%

Untouched Resources:

  package[test]                      /cookbooks/my_cookbook/recipes/default.rb:1

Untouched Recipes:

  /cookbooks/my_cookbook/recipes/another_recipe.rb
  /cookbooks/another_cookbook/recipes/default.rb
```

Unfortunately, the untouched recipe list does not respect the filters, because they are specifically designed to work only with resources.
