### PR TITLE
Restore original librarian-chef cookbook path

### DIFF
--- a/lib/chefspec/librarian.rb
+++ b/lib/chefspec/librarian.rb
@@ -25,7 +25,7 @@ module ChefSpec
     #
     def setup!
       env = ::Librarian::Chef::Environment.new(project_path: Dir.pwd)
-      env.config_db.local['path'] = @tmpdir
+      @originalpath, env.config_db.local['path'] = env.config_db.local['path'], @tmpdir
       ::Librarian::Action::Resolve.new(env).run
       ::Librarian::Action::Install.new(env).run
 
@@ -33,9 +33,12 @@ module ChefSpec
     end
 
     #
-    # Remove the temporary directory.
+    # Remove the temporary directory and restore the librarian-chef cookbook path.
     #
     def teardown!
+      env = ::Librarian::Chef::Environment.new(project_path: Dir.pwd)
+      env.config_db.local['path'] = @originalpath
+      
       FileUtils.rm_rf(@tmpdir) if File.exists?(@tmpdir)
     end
   end


### PR DESCRIPTION
setup! changes the librarian-chef install path (env.config_db.local['path']) to a temp directory for the duration of the test run.  teardown! removes the temp directory but does not reset the librarian-chef cookbook path.  One result is that, after running chefspec, "librarian-chef install" will install to the previously-used temp directory and the original cookbook location ("cookbooks" by default) becomes out of date and useless.  This overwrites even a manual setting in ./librarian/chef/config.

This solution simply remembers the original librarian-chef install path and restores it on teardown.
