### PR TITLE
Add the ability to set node object for ChefSpec::Runner

### DIFF
--- a/lib/chefspec/runner.rb
+++ b/lib/chefspec/runner.rb
@@ -138,10 +138,20 @@ module ChefSpec
     def node
       return @node if @node
 
-      @node = client.build_node
-      @node.instance_variable_set(:@runner, self)
-      @node.class.send(:attr_reader, :runner)
-      @node
+      self.node = client.build_node
+    end
+
+    #
+    # Set the node for this runner
+    #
+    # @param [Chef::Node]
+    # 
+    def node=(target)
+      raise unless target.is_a?(Chef::Node)
+      
+      @node = target
+      target.instance_variable_set(:@runner, self)
+      target.class.send(:attr_reader, :runner)
     end
 
     #

--- a/spec/unit/runner_spec.rb
+++ b/spec/unit/runner_spec.rb
@@ -133,6 +133,24 @@ describe ChefSpec::Runner do
     end
   end
 
+  describe '#node=' do
+    it 'raises an exception if a non-node object is passed' do
+      expect { subject.node = nil }.to raise_error
+    end
+    
+    it 'properly associates runner to node' do
+      subject.node = Chef::Node.new
+      expect(subject.node.methods).to include(:runner)
+      expect(subject.node.runner).to be(subject)
+    end
+
+    it 'properly associates node to runner' do
+      node = Chef::Node.new
+      subject.node = node
+      expect(node.runner).to be(subject)
+    end
+  end
+
   describe '#to_s' do
     it 'overrides the default string representation to something readable' do
       expect(subject.converge('apache2::default').to_s).to eq('chef_run: recipe[apache2::default]')


### PR DESCRIPTION
Refactor node <=> runner association out of Runner.node into
Runner.node=. Lazy initialization of Runner.node now uses
Runner.node=. This is particularly helpful when you want to stub
a number of nodes for reuse in testing multiple organizational
cookbooks.
