### PR TITLE
Minor grammar fix for documentation

### DIFF
--- a/lib/chefspec/api/erl_call.rb
+++ b/lib/chefspec/api/erl_call.rb
@@ -15,19 +15,19 @@ module ChefSpec::API
     # The Examples section demonstrates the different ways to test an
     # +erl_call+ resource with ChefSpec.
     #
-    # @example Assert that an +erl_call+ was runed
+    # @example Assert that an +erl_call+ was run
     #   expect(chef_run).to run_erl_call('net_adm:names()')
     #
-    # @example Assert that an +erl_call+ was runed with predicate matchers
+    # @example Assert that an +erl_call+ was run with predicate matchers
     #   expect(chef_run).to run_erl_call('net_adm:names()').with_node_name('example')
     #
-    # @example Assert that an +erl_call+ was runed with attributes
+    # @example Assert that an +erl_call+ was run with attributes
     #   expect(chef_run).to run_erl_call('net_adm:names()').with(node_name: 'example')
     #
-    # @example Assert that an +erl_call+ was runed using a regex
+    # @example Assert that an +erl_call+ was run using a regex
     #   expect(chef_run).to run_erl_call('net_adm:names()').with(node_name: /[a-z]+/)
     #
-    # @example Assert that an +erl_call+ was _not_ runed
+    # @example Assert that an +erl_call+ was _not_ run
     #   expect(chef_run).to_not run_erl_call('net_adm:names()')
     #
     #

--- a/lib/chefspec/api/execute.rb
+++ b/lib/chefspec/api/execute.rb
@@ -15,19 +15,19 @@ module ChefSpec::API
     # The Examples section demonstrates the different ways to test an
     # +execute+ resource with ChefSpec.
     #
-    # @example Assert that an +execute+ was runed
+    # @example Assert that an +execute+ was run
     #   expect(chef_run).to run_execute('echo "hello"')
     #
-    # @example Assert that an +execute+ was runed with predicate matchers
+    # @example Assert that an +execute+ was run with predicate matchers
     #   expect(chef_run).to run_execute('echo "hello"').with_user('svargo')
     #
-    # @example Assert that an +execute+ was runed with attributes
+    # @example Assert that an +execute+ was run with attributes
     #   expect(chef_run).to run_execute('echo "hello"').with(user: 'svargo')
     #
-    # @example Assert that an +execute+ was runed using a regex
+    # @example Assert that an +execute+ was run using a regex
     #   expect(chef_run).to run_execute('echo "hello"').with(user: /sva(.+)/)
     #
-    # @example Assert that an +execute+ was _not_ runed
+    # @example Assert that an +execute+ was _not_ run
     #   expect(chef_run).to_not run_execute('echo "hello"')
     #
     #

--- a/lib/chefspec/api/powershell_script.rb
+++ b/lib/chefspec/api/powershell_script.rb
@@ -15,19 +15,19 @@ module ChefSpec::API
     # The Examples section demonstrates the different ways to test a
     # +powershell_script+ resource with ChefSpec.
     #
-    # @example Assert that a +powershell_script+ was runed
+    # @example Assert that a +powershell_script+ was run
     #   expect(chef_run).to run_powershell_script('/tmp')
     #
-    # @example Assert that a +powershell_script+ was runed with predicate matchers
+    # @example Assert that a +powershell_script+ was run with predicate matchers
     #   expect(chef_run).to run_powershell_script('/tmp').with_user('svargo')
     #
-    # @example Assert that a +powershell_script+ was runed with attributes
+    # @example Assert that a +powershell_script+ was run with attributes
     #   expect(chef_run).to run_powershell_script('/tmp').with(user: 'svargo')
     #
-    # @example Assert that a +powershell_script+ was runed using a regex
+    # @example Assert that a +powershell_script+ was run using a regex
     #   expect(chef_run).to run_powershell_script('/tmp').with(user: /sva(.+)/)
     #
-    # @example Assert that a +powershell_script+ was _not_ runed
+    # @example Assert that a +powershell_script+ was _not_ run
     #   expect(chef_run).to_not run_powershell_script('/tmp')
     #
     #

--- a/lib/chefspec/api/ruby_block.rb
+++ b/lib/chefspec/api/ruby_block.rb
@@ -18,10 +18,10 @@ module ChefSpec::API
     # The Examples section demonstrates the different ways to test a
     # +ruby_block+ resource with ChefSpec.
     #
-    # @example Assert that a +ruby_block+ was runed
+    # @example Assert that a +ruby_block+ was run
     #   expect(chef_run).to run_ruby_block('do_something')
     #
-    # @example Assert that a +ruby_block+ was _not_ runed
+    # @example Assert that a +ruby_block+ was _not_ run
     #   expect(chef_run).to_not run_ruby_block('do_something')
     #
     #


### PR DESCRIPTION
Unleashed some minor sed action to fix up this little error in the documentation.
