### PR TITLE
test for files rendered matching start/end content

### DIFF
--- a/examples/render_file/spec/default_spec.rb
+++ b/examples/render_file/spec/default_spec.rb
@@ -23,6 +23,12 @@ describe 'render_file::default' do
       expect(chef_run).to render_file('/tmp/file').with_content(
         start_with('This')
       )
+      expect(chef_run).to render_file('/tmp/file').with_content(
+        end_with('content!')
+      )
+      expect(chef_run).to_not render_file('/tmp/file').with_content(
+        start_with('not')
+      )
       expect(chef_run).to_not render_file('/tmp/file').with_content(
         end_with('not')
       )
@@ -49,6 +55,12 @@ describe 'render_file::default' do
       it 'renders the file with content matching arbitrary matcher' do
         expect(chef_run).to render_file('/tmp/cookbook_file').with_content(
           start_with('This')
+        )
+        expect(chef_run).to render_file('/tmp/cookbook_file').with_content(
+          end_with('content!')
+        )
+        expect(chef_run).to_not render_file('/tmp/cookbook_file').with_content(
+          start_with('not')
         )
         expect(chef_run).to_not render_file('/tmp/cookbook_file').with_content(
           end_with('not')
@@ -89,6 +101,12 @@ describe 'render_file::default' do
     it 'renders the file with content matching arbitrary matcher' do
       expect(chef_run).to render_file('/tmp/template').with_content(
         start_with('This')
+      )
+      expect(chef_run).to render_file('/tmp/template').with_content(
+        end_with('content!')
+      )
+      expect(chef_run).to_not render_file('/tmp/template').with_content(
+        start_with('not')
       )
       expect(chef_run).to_not render_file('/tmp/template').with_content(
         end_with('not')


### PR DESCRIPTION
This is currently expected to fail with the following type of messages:

```
   expected Chef run to render "/tmp/template" matching:

   end with "content!"

   but got:

   This is content!
```

Unsure if this is a bug here, with rspec matchers, or with Chef file renderer for file/templates, but I exposed it while trying to write a test with ChefSpec, and was able to reproduce it in ChefSpec's cucumber testing.

I was also testing heredocs when I found this, wasn't sure if I should add/modify a resource in the emaples directory or not. Something akin to:

``` ruby
file '/tmp/file-heredoc' do
  content <<-EOF
This is content!
EOF
end
```

With no changes to the tests, this will not fail. However, attempting to test for the end_with as a positive case, i.e. "it should end with content!" will fail.
