### PR TITLE
Add ruby_block action :create matchers

### DIFF
--- a/examples/ruby_block/recipes/create.rb
+++ b/examples/ruby_block/recipes/create.rb
@@ -1,0 +1,10 @@
+ruby_block 'default_action'
+
+ruby_block 'explicit_action' do
+  action :create
+end
+
+ruby_block 'specifying the identity attribute' do
+  block_name 'identity_attribute'
+  action :create
+end

--- a/examples/ruby_block/spec/create_spec.rb
+++ b/examples/ruby_block/spec/create_spec.rb
@@ -1,0 +1,19 @@
+require 'chefspec'
+
+describe 'ruby_block::create' do
+  let(:chef_run) { ChefSpec::Runner.new.converge(described_recipe) }
+
+  it 'runs a ruby_block with the default action' do
+    expect(chef_run).to run_ruby_block('default_action')
+    expect(chef_run).to_not create_ruby_block('default_action')
+    expect(chef_run).to_not create_ruby_block('not_default_action')
+  end
+
+  it 'creates a ruby_block with an explicit action' do
+    expect(chef_run).to create_ruby_block('explicit_action')
+  end
+
+  it 'creates a ruby_block when specifying the identity attribute' do
+    expect(chef_run).to create_ruby_block('identity_attribute')
+  end
+end

--- a/features/ruby_block.feature
+++ b/features/ruby_block.feature
@@ -8,3 +8,4 @@ Feature: The ruby_block matcher
   Examples:
     | Matcher |
     | run     |
+    | create  |

--- a/lib/chefspec/api/ruby_block.rb
+++ b/lib/chefspec/api/ruby_block.rb
@@ -33,5 +33,36 @@ module ChefSpec::API
     def run_ruby_block(resource_name)
       ChefSpec::Matchers::ResourceMatcher.new(:ruby_block, :run, resource_name)
     end
+
+    #
+    # Assert that a +ruby_block+ resource exists in the Chef run with the
+    # action +:create+. Given a Chef Recipe that runs "do_something" as a
+    # +ruby_block+:
+    #
+    #     ruby_block 'do_something' do
+    #       block do
+    #         # ...
+    #       end
+    #       action :create
+    #     end
+    #
+    # The Examples section demonstrates the different ways to test a
+    # +ruby_block+ resource with ChefSpec.
+    #
+    # @example Assert that a +ruby_block+ was created
+    #   expect(chef_run).to create_ruby_block('do_something')
+    #
+    # @example Assert that a +ruby_block+ was _not_ created
+    #   expect(chef_run).to_not create_ruby_block('do_something')
+    #
+    #
+    # @param [String, Regex] resource_name
+    #   the name of the resource to match
+    #
+    # @return [ChefSpec::Matchers::ResourceMatcher]
+    #
+    def create_ruby_block(resource_name)
+      ChefSpec::Matchers::ResourceMatcher.new(:ruby_block, :create, resource_name)
+    end
   end
 end


### PR DESCRIPTION
`ruby_block` resource can receive the `:create` action. Currently it is just an [alias for `:run`](http://git.io/F2tMDQ). But I think it's important to support it, because [it is the action that appears in the official documentation](http://docs.opscode.com/resource_ruby_block.html#actions).
