### PR TITLE
Added doc on requiring spec_helper for rspec runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,14 @@ You can also specify a specific spec to run and various RSpec command line optio
 $ rspec spec/unit/recipes/default_spec.rb --color
 ```
 
+If you're using chefspec/berkshelf or wish to have command line option run by default, create a .rspec file in your cookbook directory:
+
+```bash
+--color
+--format progress
+--require spec_helper
+```
+
 For more information on the RSpec CLI, please see the [documentation](https://relishapp.com/rspec/rspec-core/docs/command-line).
 
 


### PR DESCRIPTION
As a newbie to rspec, chefspec and berkshelf, not having a .rspec file specifying the spec_helper dependency caused me a great deal of headache. 

If there's any rewording or if this fits better elsewhere, please let me know. 

Thanks!
