### PR TITLE
Updated different platform example

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Values specified at the initialization of the `Runner` merge and take precedence
 ChefSpec::Runner.new(version: '10.04')
 
 # Use a different operating system platform and version
-ChefSpec::Runner.new(platform: 'centos', version: '5.4')
+ChefSpec::Runner.new(platform: 'centos', version: '5.10')
 
 # Specify a different cookbook_path
 ChefSpec::Runner.new(cookbook_path: '/var/my/other/path', role_path: '/var/my/roles')


### PR DESCRIPTION
Fauxhai does not have 5.4 information anymore leading to weird error when using it as-is. Replaced with 5.10 which should fix usage of those that copy/paste it directly.

Here the error I was facing when using original value:

```
 Failure/Error: ChefSpec::Runner.new(:platform => 'centos', :version => '5.4').converge(described_recipe)
     Fauxhai::Exception::InvalidPlatform:
       Could not find platform 'centos/5.4' in any of the sources!
     # ./spec/recipes/default_spec.rb:15:in `block (2 levels) in <top (required)>'
     # ./spec/recipes/default_spec.rb:19:in `block (2 levels) in <top (required)>'
```

Regards,
Matt
