### PR TITLE
berkshelf filter fix and version bump

### DIFF
--- a/lib/chefspec/coverage/filters.rb
+++ b/lib/chefspec/coverage/filters.rb
@@ -68,7 +68,11 @@ module ChefSpec
       end
 
       def matches?(resource)
-        resource.source_line =~ /cookbooks\/(?!#{@metadatas.join('|')})/
+	     if (resource.source_line.nil?)
+	       return 1
+	     else
+         resource.source_line =~ /cookbooks\/(?!#{@metadatas.join('|')})/
+	     end
       end
     end
   end

--- a/lib/chefspec/version.rb
+++ b/lib/chefspec/version.rb
@@ -1,3 +1,3 @@
 module ChefSpec
-  VERSION = '4.0.2'
+  VERSION = '4.0.3'
 end


### PR DESCRIPTION
The nil check in the matches? function solves the errant metadata removal on the service resource from chef when it performs a resource clone. Both the original and the clone lose their metadata so the resource doesn't know where it's source cookbook is and therefore doesn't get filter respect. Reference #464 for closure and info.
