### PR TITLE
Add environment_path support

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ RSpec.configure do |config|
   # Specify the path for Chef Solo to find roles (default: [ascending search])
   config.role_path = '/var/roles'
 
+  # Specify the path for Chef Solo to find environments (default: [ascending search])
+  config.environment_path = '/var/environments'
+
   # Specify the Chef log_level (default: :warn)
   config.log_level = :debug
 

--- a/lib/chefspec/rspec.rb
+++ b/lib/chefspec/rspec.rb
@@ -11,6 +11,7 @@ RSpec.configure do |config|
 
   config.add_setting :cookbook_path
   config.add_setting :role_path
+  config.add_setting :environment_path
   config.add_setting :log_level, default: :warn
   config.add_setting :path
   config.add_setting :platform

--- a/lib/chefspec/solo_runner.rb
+++ b/lib/chefspec/solo_runner.rb
@@ -77,6 +77,7 @@ module ChefSpec
       Chef::Config[:role_path]       = Array(@options[:role_path])
       Chef::Config[:force_logger]    = true
       Chef::Config[:solo]            = true
+      Chef::Config[:environment_path] = @options[:environment_path]
 
       yield node if block_given?
     end
@@ -301,6 +302,7 @@ module ChefSpec
       {
         cookbook_path: config.cookbook_path || calling_cookbook_path(caller),
         role_path:     config.role_path || default_role_path,
+        environment_path: config.environment_path || default_environment_path,
         log_level:     config.log_level,
         path:          config.path,
         platform:      config.platform,
@@ -334,6 +336,20 @@ module ChefSpec
     def default_role_path
       Pathname.new(Dir.pwd).ascend do |path|
         possible = File.join(path, 'roles')
+        return possible if File.exist?(possible)
+      end
+
+      nil
+    end
+
+    #
+    # The inferred path to environments.
+    #
+    # @return [String, nil]
+    #
+    def default_environment_path
+      Pathname.new(Dir.pwd).ascend do |path|
+        possible = File.join(path, 'environments')
         return possible if File.exist?(possible)
       end
 

--- a/spec/unit/solo_runner_spec.rb
+++ b/spec/unit/solo_runner_spec.rb
@@ -104,6 +104,7 @@ describe ChefSpec::SoloRunner do
     context 'RSpec global configuration' do
       before do
         allow(RSpec.configuration).to receive(:cookbook_path).and_return('./path')
+        allow(RSpec.configuration).to receive(:environment_path).and_return('./env-path')
         allow(RSpec.configuration).to receive(:log_level).and_return(:fatal)
         allow(RSpec.configuration).to receive(:path).and_return('ohai.json')
         allow(RSpec.configuration).to receive(:platform).and_return('ubuntu')
@@ -113,6 +114,7 @@ describe ChefSpec::SoloRunner do
       it 'uses the RSpec values' do
         options = described_class.new.options
         expect(options[:cookbook_path]).to eq('./path')
+        expect(options[:environment_path]).to eq('./env-path')
         expect(options[:log_level]).to eq(:fatal)
         expect(options[:path]).to eq('ohai.json')
         expect(options[:platform]).to eq('ubuntu')


### PR DESCRIPTION
Hello! We do the monolith chef repository thing, and run `rspec` at its root to run chefspec against all our cookbooks in the `cookbooks/` folder. It works pretty well because we only have one platform & version to test against.

Anyhow, we also do a thing where some of our application cookbooks depend on attributes specified only in environment files – e.g. the environment specifies `default['mysql']['master'] = 'foobar:3306'` and then we output that value into a config file in an application cookbook.

Ideally, we would be able to test this scenario with chefspec without explicitly setting all these attributes in an rspec `before` block. It appears that chefspec supports a `role_path` configuration option (which would apply the attributes in the role at run-list-expansion-time) but there is no parallel `environment_path` option (which also applies attributes at run-list-expansion-time).

I copy-pasted the roles-related config settings, since environments are the basically the same kind of config option, but I'm happy to take any feedback and resubmit a different approach.

Cheers!
