### PR TITLE
clarify which resource is declaring a deprecated method

### DIFF
--- a/lib/chefspec/deprecations.rb
+++ b/lib/chefspec/deprecations.rb
@@ -20,6 +20,7 @@ module ChefSpec
     #   use {ChefSpec.define_runner_method} instead.
     def self.define_runner_method(resource_name)
       deprecated "`ChefSpec::Runner.define_runner_method' is deprecated. " \
+        "It is being used in the #{resource_name} resource matcher." \
         "Please use `ChefSpec.define_matcher' instead."
 
       ChefSpec.define_matcher(resource_name)

--- a/spec/unit/deprecations_spec.rb
+++ b/spec/unit/deprecations_spec.rb
@@ -16,6 +16,7 @@ describe ChefSpec::Runner do
     it 'prints a deprecation' do
       expect(ChefSpec::Runner).to receive(:deprecated)
         .with("`ChefSpec::Runner.define_runner_method' is deprecated. "\
+          "It is being used in the my_custom_resource resource matcher." \
           "Please use `ChefSpec.define_matcher' instead.")
       ChefSpec::Runner.define_runner_method(:my_custom_resource)
     end


### PR DESCRIPTION
Took me a while to figure out why I was receiving a depreciation message. It was being shown because of a resource in one of my other cookbooks was being `required` in the runner convergence. This simply includes the name of the resource in the depreciation message to make the offending resource easier to find.
