### PR TITLE
Add create_service to service api.

### DIFF
--- a/examples/service/recipes/create.rb
+++ b/examples/service/recipes/create.rb
@@ -1,0 +1,13 @@
+service 'explicit_action' do
+  action :nothing
+end
+
+service 'with_attributes' do
+  pattern 'pattern'
+  action :nothing
+end
+
+service 'specifying the identity attribute' do
+  service_name 'identity_attribute'
+  action      :nothing
+end

--- a/examples/service/spec/create_spec.rb
+++ b/examples/service/spec/create_spec.rb
@@ -1,0 +1,19 @@
+require 'chefspec'
+
+describe 'service::create' do
+  let(:chef_run) { ChefSpec::Runner.new.converge(described_recipe) }
+
+  it 'creates a service with an explicit action' do
+    expect(chef_run).to create_service('explicit_action')
+    expect(chef_run).to_not create_service('not_explicit_action')
+  end
+
+  it 'creates a service with attributes' do
+    expect(chef_run).to create_service('with_attributes').with(pattern: 'pattern')
+    expect(chef_run).to_not create_service('with_attributes').with(pattern: 'bacon')
+  end
+
+  it 'creates a service when specifying the identity attribute' do
+    expect(chef_run).to create_service('identity_attribute')
+  end
+end

--- a/features/service.feature
+++ b/features/service.feature
@@ -13,3 +13,4 @@ Feature: The service matcher
     | restart |
     | start   |
     | stop    |
+    | nothing |

--- a/lib/chefspec/api/service.rb
+++ b/lib/chefspec/api/service.rb
@@ -242,5 +242,45 @@ module ChefSpec::API
     def stop_service(resource_name)
       ChefSpec::Matchers::ResourceMatcher.new(:service, :stop, resource_name)
     end
+
+    #
+    # Assert that a +service+ resource exists in the Chef run with the
+    # action +:nothing+. Given a Chef Recipe that disables "apache2" as a
+    # +service+:
+    #
+    #     service 'apache2' do
+    #       action :nothing
+    #     end
+    #
+    # To test the content rendered by a +service+, see
+    # {ChefSpec::API::RenderFileMatchers}.
+    #
+    # The Examples section demonstrates the different ways to test a
+    # +service+ resource with ChefSpec.
+    #
+    # @example Assert that a +service+ was created
+    #   expect(chef_run).to create_service('apache2')
+    #
+    # @example Assert that a +service+ was created with predicate matchers
+    #   expect(chef_run).to create_service('apache2').with_pattern('apa*')
+    #
+    # @example Assert that a +service+ was created with attributes
+    #   expect(chef_run).to create_service('apache2').with(pattern: 'apa*')
+    #
+    # @example Assert that a +service+ was created using a regex
+    #   expect(chef_run).to create_service('apache2').with(patthen: /(.+)/)
+    #
+    # @example Assert that a +service+ was _not_ created
+    #   expect(chef_run).to_not create_service('apache2')
+    #
+    #
+    # @param [String, Regex] resource_name
+    #   the name of the resource to match
+    #
+    # @return [ChefSpec::Matchers::ResourceMatcher]
+    #
+    def create_service(resource_name)
+      ChefSpec::Matchers::ResourceMatcher.new(:service, :nothing, resource_name)
+    end
   end
 end


### PR DESCRIPTION
There are times in which a service is defined in a chef_run with a :nothing action to facilitate notifications handling the action. This API change is intended to help test those use cases.
