### PR TITLE
Tests proving behaviour outlined in #546

### DIFF
--- a/examples/notifications/libraries/matchers.rb
+++ b/examples/notifications/libraries/matchers.rb
@@ -1,0 +1,7 @@
+if defined?(ChefSpec)
+  ChefSpec.define_matcher :notifications
+
+  def test(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:notifications, :create, resource_name)
+  end
+end

--- a/examples/notifications/providers/default.rb
+++ b/examples/notifications/providers/default.rb
@@ -1,0 +1,3 @@
+action(:create) do
+  new_resource.updated_by_last_action(new_resource.name == 'update')
+end

--- a/examples/notifications/recipes/lwrp.rb
+++ b/examples/notifications/recipes/lwrp.rb
@@ -1,0 +1,13 @@
+service 'test' do
+  action :nothing
+end
+
+notifications 'update' do
+  action :create
+  notifies :restart, 'service[test]'
+end
+
+notifications 'nothing' do
+  action :create
+  notifies :restart, 'service[test]'
+end

--- a/examples/notifications/resources/default.rb
+++ b/examples/notifications/resources/default.rb
@@ -1,0 +1,2 @@
+actions :create
+attribute :name, name_attribute: true

--- a/examples/notifications/spec/lwrp_spec.rb
+++ b/examples/notifications/spec/lwrp_spec.rb
@@ -1,0 +1,26 @@
+require 'chefspec'
+
+describe 'notifications::lwrp' do
+  let(:chef_run) { ChefSpec::ServerRunner.new(step_into: ['default']).converge(described_recipe) }
+
+  it 'sends a notification to the service[test] when resource was updated by last action' do
+    notifying_resource = chef_run.notifications('update')
+    expect(notifying_resource).to notify('service[test]')
+  end
+
+  it 'sends a specific notification to the service[test] when resource was updated by last action' do
+    notifying_resource = chef_run.notifications('update')
+    expect(notifying_resource).to notify('service[test]').to(:restart)
+  end
+
+  it 'does not send a notification to the service[test] when resource was not updated by last action' do
+    notifying_resource = chef_run.notifications('nothing')
+    expect(notifying_resource).to_not notify('service[test]')
+  end
+
+  it 'does not send a specific notification to the service[test] when resource was not updated by last action' do
+    notifying_resource = chef_run.notifications('nothing')
+    expect(notifying_resource).to_not notify('service[test]').to(:restart)
+  end
+
+end

--- a/features/notifications.feature
+++ b/features/notifications.feature
@@ -11,3 +11,4 @@ Feature: The notifications matcher
     | default     |
     | delayed     |
     | immediately |
+    | lwrp        |


### PR DESCRIPTION
This is a test a requested in #546 which shows the unexpected behaviour.

```
Failures:

  1) notifications::lwrp does not send a notification to the service[test] when resource was not updated by last action
     Failure/Error: expect(notifying_resource).to_not notify('service[test]')
       expected "notifications[nothing]" to not notify "service[test]", but it did.
     # ./spec/lwrp_spec.rb:18:in `block (2 levels) in <top (required)>'

  2) notifications::lwrp does not send a specific notification to the service[test] when resource was not updated by last action
     Failure/Error: expect(notifying_resource).to_not notify('service[test]').to(:restart)
       expected "notifications[nothing]" to not notify "service[test]", but it did.
     # ./spec/lwrp_spec.rb:23:in `block (2 levels) in <top (required)>'

Finished in 28.87 seconds (files took 5.84 seconds to load)
13 examples, 2 failures

Failed examples:

rspec ./spec/lwrp_spec.rb:16 # notifications::lwrp does not send a notification to the service[test] when resource was not updated by last action
rspec ./spec/lwrp_spec.rb:21 # notifications::lwrp does not send a specific notification to the service[test] when resource was not updated by last action
```