### PR TITLE
Added possibility to specify file_cache_path globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ RSpec.configure do |config|
   # Specify the path for Chef Solo to find environments (default: [ascending search])
   config.environment_path = '/var/environments'
 
+  # Specify the path for Chef Solo file cache path (default: nil)
+  config.file_cache_path = '/var/chef/cache'
+
   # Specify the Chef log_level (default: :warn)
   config.log_level = :debug
 

--- a/lib/chefspec/rspec.rb
+++ b/lib/chefspec/rspec.rb
@@ -12,6 +12,7 @@ RSpec.configure do |config|
   config.add_setting :cookbook_path
   config.add_setting :role_path
   config.add_setting :environment_path
+  config.add_setting :file_cache_path
   config.add_setting :log_level, default: :warn
   config.add_setting :path
   config.add_setting :platform

--- a/lib/chefspec/solo_runner.rb
+++ b/lib/chefspec/solo_runner.rb
@@ -299,6 +299,7 @@ module ChefSpec
         cookbook_path: config.cookbook_path || calling_cookbook_path(caller),
         role_path:     config.role_path || default_role_path,
         environment_path: config.environment_path || default_environment_path,
+        file_cache_path: config.file_cache_path,
         log_level:     config.log_level,
         path:          config.path,
         platform:      config.platform,

--- a/spec/unit/solo_runner_spec.rb
+++ b/spec/unit/solo_runner_spec.rb
@@ -110,6 +110,7 @@ describe ChefSpec::SoloRunner do
       before do
         allow(RSpec.configuration).to receive(:cookbook_path).and_return('./path')
         allow(RSpec.configuration).to receive(:environment_path).and_return('./env-path')
+        allow(RSpec.configuration).to receive(:file_cache_path).and_return('./file-cache-path')
         allow(RSpec.configuration).to receive(:log_level).and_return(:fatal)
         allow(RSpec.configuration).to receive(:path).and_return('ohai.json')
         allow(RSpec.configuration).to receive(:platform).and_return('ubuntu')
@@ -120,6 +121,7 @@ describe ChefSpec::SoloRunner do
         options = described_class.new.options
         expect(options[:cookbook_path]).to eq('./path')
         expect(options[:environment_path]).to eq('./env-path')
+        expect(options[:file_cache_path]).to eq('./file-cache-path')
         expect(options[:log_level]).to eq(:fatal)
         expect(options[:path]).to eq('ohai.json')
         expect(options[:platform]).to eq('ubuntu')


### PR DESCRIPTION
Instead of repeating `file_cache_path: /path` as an option to all new runners I was creating, I added the option to specify the `file_cache_path` globally inside the RSpec configuration.

