### PR TITLE
Fix for using helper methods in nested templates

### DIFF
--- a/lib/chefspec/renderer.rb
+++ b/lib/chefspec/renderer.rb
@@ -68,12 +68,10 @@ module ChefSpec
         template_context = Chef::Mixin::Template::TemplateContext.new([])
         template_context.update({
           :node => chef_run.node,
-          :template_finder => template_finder(chef_run, template.cookbook_name),
+          :template_finder => template_finder(chef_run, cookbook_name),
         }.merge(template.variables))
         if template.respond_to?(:helper_modules) # Chef 11.4+
-          template.helper_modules.each do |helper_module|
-            template_context.extend(helper_module)
-          end
+          template_context._extend_modules(template.helper_modules)
         end
         template_context.render_template(template_location)
       else


### PR DESCRIPTION
The helper modules for rendering tempates are extended by the TemplateContext and used for rendering. 
In Chefspec, this was not working for nested templates because chef uses @_extended_modules variable to pass it on to rendering partials. This fix uses the _extend_modules method to fix this