### PR TITLE
Fix for Chef 12.1.0 masking exceptions in converge.

### DIFF
--- a/lib/chefspec/solo_runner.rb
+++ b/lib/chefspec/solo_runner.rb
@@ -118,7 +118,10 @@ module ChefSpec
       yield if block_given?
 
       @converging = true
-      @client.converge(@run_context)
+      converge_val = @client.converge(@run_context)
+      if converge_val.is_a?(Exception)
+        raise converge_val
+      end
       self
     end
 


### PR DESCRIPTION
This is being tracked upstream in https://github.com/chef/chef/issues/3078. The behavior of converge changed from re-raising exceptions to returning them. This will hopefully be resolved in 12.1.2 but this code will be needed to match things up for 12.1.0 and 12.1.1. Without this, you cannot test for exceptions being raised by recipe code.