### PR TITLE
Fix link to website

### DIFF
--- a/chefspec.gemspec
+++ b/chefspec.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
                     'ChefSpec makes it easy to write examples and get fast ' \
                     'feedback on cookbook changes without the need for ' \
                     'virtual machines or cloud servers.'
-  s.homepage      = 'http://code.sethvargo.com/chefspec'
+  s.homepage      = 'https://sethvargo.github.io/chefspec/'
   s.license       = 'MIT'
 
   # Packaging


### PR DESCRIPTION
http://code.sethvargo.com/chefspec is a 404 and http://code.sethvargo.com/ also displays the ChefSpec, so I'm not sure if https://sethvargo.github.io/chefspec/ should be the one linked in the gemspec