### PR TITLE
Windows directory rights

### DIFF
--- a/examples/directory/recipes/create.rb
+++ b/examples/directory/recipes/create.rb
@@ -12,3 +12,7 @@ end
 directory 'specifying the identity attribute' do
   path '/tmp/identity_attribute'
 end
+
+directory 'c:\temp\with_windows_rights' do
+  rights :read_execute, 'Users', applies_to_children: true
+end

--- a/examples/directory/spec/create_spec.rb
+++ b/examples/directory/spec/create_spec.rb
@@ -24,6 +24,10 @@ describe 'directory::create' do
     )
   end
 
+  it 'creates a directory with windows rights' do
+    expect(chef_run).to create_directory('c:\temp\with_windows_rights').with(rights: [{:permissions=>:read_execute, :principals=>"Users", :applies_to_children=>true}])
+  end
+
   it 'creates a directory when specifying the identity attribute' do
     expect(chef_run).to create_directory('/tmp/identity_attribute')
   end

--- a/lib/chefspec.rb
+++ b/lib/chefspec.rb
@@ -42,13 +42,13 @@ module ChefSpec
   module_function :matchers
 end
 
+require_relative 'chefspec/extensions/chef/securable'
 require_relative 'chefspec/extensions/chef/client'
 require_relative 'chefspec/extensions/chef/conditional'
 require_relative 'chefspec/extensions/chef/cookbook_uploader'
 require_relative 'chefspec/extensions/chef/data_query'
 require_relative 'chefspec/extensions/chef/lwrp_base'
 require_relative 'chefspec/extensions/chef/resource'
-require_relative 'chefspec/extensions/chef/securable'
 require_relative 'chefspec/extensions/chef/resource/freebsd_package'
 
 require_relative 'chefspec/mixins/normalize'


### PR DESCRIPTION
This PR adds testing for windows directories that use the `rights` attribute and adds a fix when using windows directories that use the `rights` attribute.

Fixes #575 