### PR TITLE
Add a failing test and fix for #582 (package identity attribute not matched)

### DIFF
--- a/examples/package/spec/install_spec.rb
+++ b/examples/package/spec/install_spec.rb
@@ -22,7 +22,7 @@ describe 'package::install' do
   end
   
   context 'with fauxhai data provided' do
-    let (: chef_run) {
+    let (:chef_run) {
       ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '14.04').converge(described_recipe)
     }
     

--- a/examples/package/spec/install_spec.rb
+++ b/examples/package/spec/install_spec.rb
@@ -20,4 +20,15 @@ describe 'package::install' do
   it 'installs a package when specifying the identity attribute' do
     expect(chef_run).to install_package('identity_attribute')
   end
+  
+  context 'with fauxhai data provided' do
+    let (: chef_run) {
+      ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '14.04').converge(described_recipe)
+    }
+    
+    it 'installs a package when specifying the identity attribute too' do
+      expect(chef_run).to install_package('identity_attribute')
+    end
+  end
+
 end

--- a/lib/chefspec/mixins/normalize.rb
+++ b/lib/chefspec/mixins/normalize.rb
@@ -9,7 +9,13 @@ module ChefSpec
     # @return [Symbol]
     #
     def resource_name(thing)
-      name = thing.respond_to?(:resource_name) ? thing.resource_name : thing
+      if thing.respond_to?(:declared_type)
+        name = thing.declared_type
+      elsif thing.respond_to?(:resource_name)
+        name = thing.resource_name
+      else
+        name = thing
+      end
       name.to_s.gsub('-', '_').to_sym
     end
   end


### PR DESCRIPTION
This PR adds a failing test to demonstrate the issue described in #582 

It shows that the package identity attribute works with Chef 11.x, but not with Chef 12.x

Someone wants to jump in for fixing this?
