### PR TITLE
Filter Windows and Unix paths for test coverage report with Berkshelf.

### DIFF
--- a/lib/chefspec/coverage/filters.rb
+++ b/lib/chefspec/coverage/filters.rb
@@ -71,7 +71,8 @@ module ChefSpec
 
       def matches?(resource)
         return true if resource.source_line.nil?
-        resource.source_line =~ /cookbooks\/(?!#{@metadatas.join('|')})/
+        normalized_source_line = resource.source_line.gsub("\\", "/")
+        normalized_source_line=~ /cookbooks\/(?!#{@metadatas.join('|')})/
       end
     end
   end

--- a/spec/unit/coverage/filters_spec.rb
+++ b/spec/unit/coverage/filters_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+
+# Note: These specs don't use Berkshelf code directly as this project doesn't
+# have a direct dependency on Berkshelf and loading it would impact the
+# perfance of these specs. While not ideal, the test doubles provide enough of
+# a standin for Berkshelf to exercise the `#matches?` behavior.
+describe ChefSpec::Coverage::BerkshelfFilter do
+  let(:dependencies) do
+    [double('Berkshelf::Dependency', metadata?: true, name: "cookbookery")]
+  end
+  let(:berksfile) { double('Berkshelf::Berksfile', dependencies: dependencies) }
+  let(:resource) { Chef::Resource.new('theone') }
+  subject { described_class.new(berksfile) }
+
+  describe '#matches?' do
+    it 'returns truthy if resource source_line is nil' do
+      expect(subject.matches?(resource)).to be_truthy
+    end
+
+    context 'when resource#source_line is under target cookbook' do
+      it 'normal unix path returns truthy' do
+        resource.source_line =
+          '/path/to/cookbooks/nope/recipes/default.rb:22'
+        expect(subject.matches?(resource)).to be_truthy
+      end
+
+      it 'normal windows path returns truthy' do
+        resource.source_line =
+          'C:\\path\\to\\cookbooks\\nope\\recipes\\default.rb:22'
+        expect(subject.matches?(resource)).to be_truthy
+      end
+
+      it 'mixed windows path returns truthy' do
+        resource.source_line =
+          'C:\\path\\to\\cookbooks/nope/recipes/default.rb:22'
+        expect(subject.matches?(resource)).to be_truthy
+      end
+    end
+
+    context 'when resource#source_line is not under target cookbook' do
+      it 'normal unix path returns falsey' do
+        resource.source_line =
+          '/path/to/cookbooks/cookbookery/recipes/default.rb:22'
+        expect(subject.matches?(resource)).to be_falsey
+      end
+
+      it 'normal windows path returns falsey' do
+        resource.source_line =
+          'C:\\path\\to\\cookbooks\\cookbookery\\recipes\\default.rb:22'
+        expect(subject.matches?(resource)).to be_falsey
+      end
+
+      it 'mixed windows path returns falsey' do
+        resource.source_line =
+          'C:\\path\\to\\cookbooks/cookbookery/recipes/default.rb:22'
+        expect(subject.matches?(resource)).to be_falsey
+      end
+    end
+  end
+end


### PR DESCRIPTION
In debugging this issue on Windows, it turns out that a Resource's
`#source_line` could be a path with Windows-style back slashes:

    C:\Users\jdoe\AppData\Local\Temp\xxyy\cookbooks\logrotate\recipes\default.rb:20

or a path with Unix-style forward slashes:

    C:/Users/jdoe/AppData/Local/Temp/xxyy/cookbooks/logrotate/recipes/default.rb:20

This commit normalizes the path delimeters to always be Unix-style
forward slashes for the purpose of Regexp comparison.

To guard against any behavior regressions in
`ChefSpec::Coverage::BerkshelfFilter`, a minimal set of specs was added
to exercise the behavior of the `#matches?` method. Normally, we would
require the Berkshelf codebase to create a `Berkshelf::Berksfile`
instance, but due to the soft-dependency nature of the Berkshelf code
(i.e. optional and not required), a couple of Rspec code doubles was
used instead to mimic the `Berksfile`'s behavior.

Fixes #594