### PR TITLE
Only use declared_type if not nil.

### DIFF
--- a/lib/chefspec/mixins/normalize.rb
+++ b/lib/chefspec/mixins/normalize.rb
@@ -9,7 +9,7 @@ module ChefSpec
     # @return [Symbol]
     #
     def resource_name(thing)
-      if thing.respond_to?(:declared_type)
+      if thing.respond_to?(:declared_type) && thing.declared_type
         name = thing.declared_type
       elsif thing.respond_to?(:resource_name)
         name = thing.resource_name


### PR DESCRIPTION
This can end up happening if you are doing weird stuff with manually creating resource objects. Should be safe to ignore if unset.