### PR TITLE
Add changelog and bump up version for 4.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 CHANGELOG for ChefSpec
 ======================
 
+## 4.4.0 (September 18, 2015)
+
+Bugfixes
+  - Documentation improvements (using regex in stubbed commands, chef 12+ custom matcher gotchas)
+  - Spec suite improvements (dsc resource specs, platform specific configurations)
+  - Chef 12+ platform specific resource loading related error
+
+Improvements
+  - Support for policy files
+
 ## 4.3.0 (July 16, 2015)
 
 Bugfixes:

--- a/chefspec.gemspec
+++ b/chefspec.gemspec
@@ -26,10 +26,9 @@ Gem::Specification.new do |s|
   # ChefSpec requires Ruby 1.9+
   s.required_ruby_version = '>= 1.9'
 
-  s.add_dependency 'chef',      '>= 11.14'
-  s.add_dependency 'chef-zero', '~> 4.2.3'
-  s.add_dependency 'fauxhai',   '~> 2.3'
-  s.add_dependency 'rspec',     '~> 3.0'
+  s.add_dependency 'chef',    '>= 11.14'
+  s.add_dependency 'fauxhai', '~> 2.3'
+  s.add_dependency 'rspec',   '~> 3.0'
 
   # Development Dependencies
   s.add_development_dependency 'rake'

--- a/chefspec.gemspec
+++ b/chefspec.gemspec
@@ -26,9 +26,10 @@ Gem::Specification.new do |s|
   # ChefSpec requires Ruby 1.9+
   s.required_ruby_version = '>= 1.9'
 
-  s.add_dependency 'chef',    '>= 11.14'
-  s.add_dependency 'fauxhai', '~> 2.3'
-  s.add_dependency 'rspec',   '~> 3.0'
+  s.add_dependency 'chef',      '>= 11.14'
+  s.add_dependency 'chef-zero', '~> 4.2.3'
+  s.add_dependency 'fauxhai',   '~> 2.3'
+  s.add_dependency 'rspec',     '~> 3.0'
 
   # Development Dependencies
   s.add_development_dependency 'rake'

--- a/lib/chefspec/version.rb
+++ b/lib/chefspec/version.rb
@@ -1,3 +1,3 @@
 module ChefSpec
-  VERSION = '4.3.0'
+  VERSION = '4.4.0'
 end


### PR DESCRIPTION
@sethvargo we have to cut a new release for impending ChefDK release to support policy file based specs. Let me know if you want me to cut the release.