### PR TITLE
Add have_attribute matchers to Chef::Resource

### DIFF
--- a/lib/chefspec/extensions/chef/resource.rb
+++ b/lib/chefspec/extensions/chef/resource.rb
@@ -30,6 +30,20 @@ class Chef::Resource
     end
   end
 
+  alias_method :old_method_missing, :method_missing
+  def method_missing(method_name, *arguments, &block)
+    if method_name.to_s =~ /has_(.*)\?/
+      send($1) == arguments.first
+    else
+      old_method_missing(method_name, *arguments, &block)
+    end
+  end
+
+  alias_method :old_respond_to?, :respond_to?
+  def respond_to?(method_name, include_private = false)
+    method_name.to_s =~ /has_(.*)\?/ || old_respond_to?(method_name, include_private)
+  end
+
   def perform_action(action, options = {})
     @performed_actions[action.to_sym] ||= {}
     @performed_actions[action.to_sym].merge!(options)
@@ -42,6 +56,7 @@ class Chef::Resource
   def performed_action?(action)
     !!performed_action(action)
   end
+  alias_method :has_performed_action?, :performed_action?
 
   def performed_actions
     @performed_actions.keys


### PR DESCRIPTION
This adds has_(attribute)? methods to Chef::Resource and its
descendants, enabling testers to write blocks like the following in the
context of a chef resource as the subject:

it { is_expected.to have_performed_action(:create) }

(for a user resource)
it { is_expected.to have_members([user]) }

(for a file resource)
it { is_expected.to have_mode('0640') }

and so on and so forth. I think this could allow users to better follow
the guidelines at betterspecs.org, and also has great benefits with
--format documentation output.