### PR TITLE
Attempting to support do/end syntax to block passed to with_content

### DIFF
--- a/lib/chefspec/matchers/render_file_matcher.rb
+++ b/lib/chefspec/matchers/render_file_matcher.rb
@@ -1,5 +1,6 @@
 module ChefSpec::Matchers
   class RenderFileMatcher
+    attr_reader :expected_content
     def initialize(path)
       @path = path
     end
@@ -20,7 +21,7 @@ module ChefSpec::Matchers
         raise ArgumentError, "Cannot specify expected content and a block!"
       elsif expected_content
         @expected_content = expected_content
-      elsif block
+      elsif block_given?
         @expected_content = block
       else
         raise ArgumentError, "Must specify expected content or a block!"

--- a/spec/unit/matchers/render_file_matcher_spec.rb
+++ b/spec/unit/matchers/render_file_matcher_spec.rb
@@ -6,6 +6,17 @@ describe ChefSpec::Matchers::RenderFileMatcher do
   let(:chef_run) { double('chef run', find_resource: file) }
   subject { described_class.new(path) }
 
+  describe '#with_content' do
+    it 'accepts do/end syntax' do
+      subject.matches?(chef_run)
+      expect(
+        subject.with_content do |content|
+          'Does not raise ArgumentError'
+        end.expected_content.call
+      ).to eq('Does not raise ArgumentError')
+    end
+  end
+
   describe '#failure_message' do
     it 'has the right value' do
       subject.matches?(chef_run)


### PR DESCRIPTION
ChefSpec::Matchers::RenderFileMatcher#with_content does not currently
support passing blocks using do/end syntax. I believe that
Kernel#block_given? should be a better method of detecting a block
passed to the method.

In order to present a unit test, I needed to expose
ChefSpec::Matchers::RenderFileMatcher@expected_content as an
attr_reader. If there is a way of testing this against an actual
recipe file, please let me know.