### PR TITLE
Compat fix for Policyfile integration

### DIFF
--- a/lib/chefspec/policyfile.rb
+++ b/lib/chefspec/policyfile.rb
@@ -23,7 +23,6 @@ module ChefSpec
     #
     def setup!
       policyfile_path = File.join(Dir.pwd, 'Policyfile.rb')
-      cbdir = File.join(@tmpdir, 'cookbooks')
 
       installer = ChefDK::PolicyfileServices::Install.new(
         policyfile: policyfile_path,
@@ -40,7 +39,12 @@ module ChefSpec
       FileUtils.rm_rf(@tmpdir)
       exporter.run
 
-      ::RSpec.configure { |config| config.cookbook_path = cbdir }
+      ::RSpec.configure do |config|
+        config.cookbook_path = [
+          File.join(@tmpdir, 'cookbooks'),
+          File.join(@tmpdir, 'cookbook_artifacts')
+        ]
+      end
     end
 
     #


### PR DESCRIPTION
With [this](https://github.com/chef/chef-dk/commit/0a3aee0efe774876b5d322c21015dff50fbf876b#diff-ae38d50dbb65fc1a07c910fdbbaf9ddd) commit, chef-dk gem has changed the functionality to export the cookbooks into `cookbook_artifacts` directory instead of `cookbooks` directory. 

This PR contains the change required to support that. 

I think the correct thing to do will be to make a chef-dk release and set the `cbdir` here based on the chef-dk version in order to support the newer and the older versions. 

What do you guys think? @danielsdeleo, @jtimberman @sethvargo 