### PR TITLE
Add chocolatey_package matchers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ gemfile: gemfiles/chefspec.gemfile
 
 env:
   - CHEF_VERSION=master
+  - CHEF_VERSION=12.7.2
   - CHEF_VERSION=12.6.0
   - CHEF_VERSION=12.5.1
   - CHEF_VERSION=12.4.3

--- a/examples/chocolatey_package/recipes/install.rb
+++ b/examples/chocolatey_package/recipes/install.rb
@@ -1,0 +1,6 @@
+chocolatey_package '7zip'
+
+chocolatey_package 'git' do
+  version '2.7.1'
+  options '--params /GitAndUnixToolsOnPath'
+end

--- a/examples/chocolatey_package/recipes/remove.rb
+++ b/examples/chocolatey_package/recipes/remove.rb
@@ -1,0 +1,8 @@
+chocolatey_package '7zip' do
+  action :remove
+end
+
+chocolatey_package 'git' do
+  version '2.7.1'
+  action :remove
+end

--- a/examples/chocolatey_package/recipes/upgrade.rb
+++ b/examples/chocolatey_package/recipes/upgrade.rb
@@ -1,0 +1,8 @@
+chocolatey_package '7zip' do
+  action :upgrade
+end
+
+chocolatey_package 'git' do
+  version '2.7.1'
+  action :upgrade
+end

--- a/examples/chocolatey_package/spec/install_spec.rb
+++ b/examples/chocolatey_package/spec/install_spec.rb
@@ -1,0 +1,21 @@
+require 'chefspec'
+
+RSpec.configure do |config|
+  config.platform = 'windows'
+  config.version  = '2012R2'
+end
+
+describe 'chocolatey_package::install' do
+  let(:chef_run) { ChefSpec::SoloRunner.converge(described_recipe) }
+
+  it 'installs a package' do
+    expect(chef_run).to install_chocolatey_package('7zip')
+  end
+
+  it 'installs a specific version of a package with options' do
+    expect(chef_run).to install_chocolatey_package('git').with(
+      version: %w(2.7.1),
+      options: '--params /GitAndUnixToolsOnPath'
+    )
+  end
+end

--- a/examples/chocolatey_package/spec/remove_spec.rb
+++ b/examples/chocolatey_package/spec/remove_spec.rb
@@ -1,0 +1,20 @@
+require 'chefspec'
+
+RSpec.configure do |config|
+  config.platform = 'windows'
+  config.version  = '2012R2'
+end
+
+describe 'chocolatey_package::remove' do
+  let(:chef_run) { ChefSpec::SoloRunner.converge(described_recipe) }
+
+  it 'removes a package' do
+    expect(chef_run).to remove_chocolatey_package('7zip')
+  end
+
+  it 'removes a specific version of a package with options' do
+    expect(chef_run).to remove_chocolatey_package('git').with(
+      version: %w(2.7.1)
+    )
+  end
+end

--- a/examples/chocolatey_package/spec/upgrade_spec.rb
+++ b/examples/chocolatey_package/spec/upgrade_spec.rb
@@ -1,0 +1,20 @@
+require 'chefspec'
+
+RSpec.configure do |config|
+  config.platform = 'windows'
+  config.version  = '2012R2'
+end
+
+describe 'chocolatey_package::upgrade' do
+  let(:chef_run) { ChefSpec::SoloRunner.converge(described_recipe) }
+
+  it 'upgrades a package' do
+    expect(chef_run).to upgrade_chocolatey_package('7zip')
+  end
+
+  it 'upgrades a specific version of a package with options' do
+    expect(chef_run).to upgrade_chocolatey_package('git').with(
+      version: %w(2.7.1)
+    )
+  end
+end

--- a/features/chocolatey_package.feature
+++ b/features/chocolatey_package.feature
@@ -26,3 +26,4 @@ Feature: The chocolatey_package matcher
     | Matcher |
     | install |
     | remove  |
+    | upgrade |

--- a/features/chocolatey_package.feature
+++ b/features/chocolatey_package.feature
@@ -1,0 +1,28 @@
+@not_chef_11_14_2
+@not_chef_11_14_6
+@not_chef_11_16_0
+@not_chef_11_16_2
+@not_chef_11_16_4
+@not_chef_11_18_0
+@not_chef_11_18_6
+@not_chef_12_0_3
+@not_chef_12_1_0
+@not_chef_12_1_1
+@not_chef_12_1_2
+@not_chef_12_2_1
+@not_chef_12_3_0
+@not_chef_12_4_0
+@not_chef_12_4_3
+@not_chef_12_5_1
+@not_chef_12_6_0
+Feature: The chocolatey_package matcher
+  Background:
+    * I am using the "chocolatey_package" cookbook
+
+  Scenario Outline: Running specs
+    * I successfully run `rspec spec/<Matcher>_spec.rb`
+    * the output should contain "0 failures"
+  Examples:
+    | Matcher |
+    | install |
+    | remove  |

--- a/lib/chefspec/api.rb
+++ b/lib/chefspec/api.rb
@@ -27,6 +27,7 @@ end
 require_relative 'api/apt_package'
 require_relative 'api/batch'
 require_relative 'api/chef_gem'
+require_relative 'api/chocolatey_package'
 require_relative 'api/cookbook_file'
 require_relative 'api/cron'
 require_relative 'api/deploy'

--- a/lib/chefspec/api/chocolatey_package.rb
+++ b/lib/chefspec/api/chocolatey_package.rb
@@ -1,0 +1,107 @@
+module ChefSpec::API
+  # @since 4.6.0
+  module ChocolateyPackageMatchers
+    ChefSpec.define_matcher :chocolatey_package
+    #
+    # Assert that a +chocolatey_package+ resource exists in the Chef run with the
+    # action +:install+. Given a Chef Recipe that installs "7zip" as a
+    # +chocolatey_package+:
+    #
+    #     chocolatey_package '7zip' do
+    #       action :install
+    #     end
+    #
+    # The Examples section demonstrates the different ways to test a
+    # +chocolatey_package+ resource with ChefSpec.
+    #
+    # @example Assert that a +chocolatey_package+ was installed
+    #   expect(chef_run).to install_chocolatey_package('7zip')
+    #
+    # @example Assert that a +chocolatey_package+ was installed with attributes
+    #   expect(chef_run).to install_chocolatey_package('git').with(
+    #     version: '2.7.1',
+    #     options: '--params /GitAndUnixToolsOnPath'
+    #  )
+    #
+    # @example Assert that a +chocolatey_package+ was _not_ installed
+    #   expect(chef_run).to_not install_chocolatey_package('flashplayeractivex')
+    #
+    # @param [String, Regex] resource_name
+    #   the name of the resource to match
+    #
+    # @return [ChefSpec::Matchers::ResourceMatcher]
+    #
+    def install_chocolatey_package(resource_name)
+      ChefSpec::Matchers::ResourceMatcher.new(:chocolatey_package, :install, resource_name)
+    end
+
+    #
+    # Assert that a +chocolatey_package+ resource exists in the Chef run with the
+    # action +:remove+. Given a Chef Recipe that removes "7zip" as a
+    # +chocolatey_package+:
+    #
+    #     chocolatey_package '7zip' do
+    #       action :remove
+    #     end
+    #
+    # To test the content rendered by a +chocolatey_package+, see
+    # {ChefSpec::API::RenderFileMatchers}.
+    #
+    # The Examples section demonstrates the different ways to test a
+    # +chocolatey_package+ resource with ChefSpec.
+    #
+    # @example Assert that a +chocolatey_package+ was removed
+    #   expect(chef_run).to remove_chocolatey_package('7zip')
+    #
+    # @example Assert that a specific +chocolatey_package+ version was removed
+    #   expect(chef_run).to remove_chocolatey_package('7zip').with(
+    #     version: '15.14'
+    #   )
+    #
+    # @example Assert that a +chocolatey_package+ was _not_ removed
+    #   expect(chef_run).to_not remove_chocolatey_package('7zip')
+    #
+    #
+    # @param [String, Regex] resource_name
+    #   the name of the resource to match
+    #
+    # @return [ChefSpec::Matchers::ResourceMatcher]
+    #
+    def remove_chocolatey_package(resource_name)
+      ChefSpec::Matchers::ResourceMatcher.new(:chocolatey_package, :remove, resource_name)
+    end
+
+    #
+    # Assert that a +chocolatey_package+ resource exists in the Chef run with the
+    # action +:upgrade+. Given a Chef Recipe that upgrades "7zip" as a
+    # +chocolatey_package+:
+    #
+    #     chocolatey_package '7zip' do
+    #       action :upgrade
+    #     end
+    #
+    # The Examples section demonstrates the different ways to test a
+    # +chocolatey_package+ resource with ChefSpec.
+    #
+    # @example Assert that a +chocolatey_package+ was upgraded
+    #   expect(chef_run).to upgrade_chocolatey_package('7zip')
+    #
+    # @example Assert that a +chocolatey_package+ was upgraded with attributes
+    #   expect(chef_run).to upgrade_chocolatey_package('git').with(
+    #     version: '2.7.1',
+    #     options: '-params "/GitAndUnixToolsOnPath"'
+    #  )
+    #
+    # @example Assert that a +chocolatey_package+ was _not_ upgraded
+    #   expect(chef_run).to_not upgrade_chocolatey_package('flashplayeractivex')
+    #
+    # @param [String, Regex] resource_name
+    #   the name of the resource to match
+    #
+    # @return [ChefSpec::Matchers::ResourceMatcher]
+    #
+    def upgrade_chocolatey_package(resource_name)
+      ChefSpec::Matchers::ResourceMatcher.new(:chocolatey_package, :upgrade, resource_name)
+    end
+  end
+end

--- a/lib/chefspec/api/chocolatey_package.rb
+++ b/lib/chefspec/api/chocolatey_package.rb
@@ -19,7 +19,7 @@ module ChefSpec::API
     #
     # @example Assert that a +chocolatey_package+ was installed with attributes
     #   expect(chef_run).to install_chocolatey_package('git').with(
-    #     version: '2.7.1',
+    #     version: %w(2.7.1),
     #     options: '--params /GitAndUnixToolsOnPath'
     #  )
     #
@@ -55,7 +55,7 @@ module ChefSpec::API
     #
     # @example Assert that a specific +chocolatey_package+ version was removed
     #   expect(chef_run).to remove_chocolatey_package('7zip').with(
-    #     version: '15.14'
+    #     version: %w(15.14)
     #   )
     #
     # @example Assert that a +chocolatey_package+ was _not_ removed
@@ -88,7 +88,7 @@ module ChefSpec::API
     #
     # @example Assert that a +chocolatey_package+ was upgraded with attributes
     #   expect(chef_run).to upgrade_chocolatey_package('git').with(
-    #     version: '2.7.1',
+    #     version: %w(2.7.1),
     #     options: '-params "/GitAndUnixToolsOnPath"'
     #  )
     #


### PR DESCRIPTION
[Chef Client 12.7.2](https://docs.chef.io/release/12-7/release_notes.html) introduced the chocolatey_package resource.

Fixes #673

### Note
chocolatey_package coerces version strings into arrays. You must specify
the version as an array in your examples.

### Example Recipe:
```ruby
chocolatey_package 'git' do
  version '2.7.1'
end
```

### Example Spec:
```ruby
it 'installs git 2.7.1' do
  expect(chef_run).to install_chocolatey_package('git').with(
    version: %w(2.7.1)
  )
end
```