### PR TITLE
Making every Chef run under the ServerRunner use the same :file_cache_path

### DIFF
--- a/lib/chefspec/rspec.rb
+++ b/lib/chefspec/rspec.rb
@@ -18,4 +18,9 @@ RSpec.configure do |config|
   config.add_setting :path
   config.add_setting :platform
   config.add_setting :version
+
+  # Sometimes we need a constant location to use for the file_cache_path and
+  # initializing it here ensures it is available later if needed
+  config.class::FILE_CACHE_PATH = Dir.mktmpdir
+  at_exit { FileUtils.rm_rf(config.class::FILE_CACHE_PATH) }
 end

--- a/lib/chefspec/server_runner.rb
+++ b/lib/chefspec/server_runner.rb
@@ -11,6 +11,12 @@ module ChefSpec
 
     # @see (SoloRunner#initialize)
     def initialize(options = {})
+      # Unlike the SoloRunner, the file_cache_path needs to remain consistent
+      # for every Chef run.  Else the Chef client tries to loads the same
+      # cookbook multiple times and will encounter deprecated logic when
+      # creating LWRPs.
+      options[:file_cache_path] ||= ::RSpec.configuration.class::FILE_CACHE_PATH
+
       # Call super, but do not pass in the block because we want to customize
       # our yielding.
       super(options, &nil)
@@ -98,24 +104,6 @@ module ChefSpec
       @server.close
 
       return @port
-    end
-
-    #
-    # The path to cache files on disk.  Unlike the SoloRunner, this path needs
-    # to remain consistent for every Chef run.  Else the Chef client tries to
-    # loads the same cookbook multiple times and will encounter deprecated logic
-    # when creating LWRPs.  This method can be removed when the deprecated logic
-    # is removed.
-    #
-    # The method adds a {Kernel.at_exit} handler to ensure the temporary
-    # directory is deleted when the system exits.
-    #
-    def file_cache_path
-      @@file_cache_path ||= begin
-        d = Dir.mktmpdir
-        at_exit { FileUtils.rm_rf(d) }
-        d
-      end
     end
 
   end

--- a/lib/chefspec/server_runner.rb
+++ b/lib/chefspec/server_runner.rb
@@ -99,5 +99,24 @@ module ChefSpec
 
       return @port
     end
+
+    #
+    # The path to cache files on disk.  Unlike the SoloRunner, this path needs
+    # to remain consistent for every Chef run.  Else the Chef client tries to
+    # loads the same cookbook multiple times and will encounter deprecated logic
+    # when creating LWRPs.  This method can be removed when the deprecated logic
+    # is removed.
+    #
+    # The method adds a {Kernel.at_exit} handler to ensure the temporary
+    # directory is deleted when the system exits.
+    #
+    def file_cache_path
+      @@file_cache_path ||= begin
+        d = Dir.mktmpdir
+        at_exit { FileUtils.rm_rf(d) }
+        d
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Fixes https://github.com/chef/chef/issues/4668

Okay, so here is the story on this one:

* The `ServerRunner` sets [`Chef::Config[:file_cache_path]`](https://github.com/sethvargo/chefspec/blob/622a05b9f362f4219d0b89825d543518a9998ebf/lib/chefspec/solo_runner.rb#L76) to a new value every time it is initialized.
* In turn this causes cookbooks to be synchronized to a different folder every time Chef is converged.
* Recent versions of Chef 12 use the `LWRPBase.loaded_lwrps` hash to [determine](https://github.com/chef/chef/blob/v12.8.4/lib/chef/provider/lwrp_base.rb#L55) if an LWRP has been loaded yet.  This hash is keyed off the full filename of the LWRP.
* Because each Chef converge occurs in the same Ruby process and uses a different `file_cache_path` it is possible for the same LWRP to be loaded multiple times.
  * For example, `/tmp/run1/cookbooks/apt/providers/preference.rb` is loaded by the first Chef converge.  The second Chef converge loads `/tmp/run2/cookbooks/apt/providers/preference.rb` because the full path of the `preference` LWRP is different than the first run.
* This causes the [warning](https://github.com/chef/chef/blob/v12.8.4/lib/chef/resource.rb#L1540) listed in the original issue.
  * The full file paths are different so the hash in `LWRPBase` does not prevent the reloading, but the files both try to define the same class - `AptPreference`.

I see two potential solutions to this issue:

1. Make every Chef converge kicked off by the ServerRunner use the same `Chef::Config[:file_cache_path]`.  Every Chef converge put the same cookbooks (locked by Berkshelf or a Policyfile) into different caches, so this just makes those caches the same folder.  This is my prefered solution.
2. Expand the [`chef_backwards_compat`](https://github.com/sethvargo/chefspec/blob/622a05b9f362f4219d0b89825d543518a9998ebf/lib/chefspec/chef_backwards_compat.rb#L46-L52) logic to apply to Chef 12 as well as Chef 11.  This attempts to find those LWRP constants defined on `Chef::Provider` and delete them before re-loading the files each time.

Tested with many versions of Chef 12 (12.2, 12.4, 12.6+) and this solution got rid of the warning for all versions.

\cc @sethvargo @chefsalim @randomcamel @jkeiser 

@sethvargo I didn't see any tests for this - am I missing them somewhere?