### PR TITLE
Fix failing Macros spec due to Fauxhai change

### DIFF
--- a/chefspec.gemspec
+++ b/chefspec.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9'
 
   s.add_dependency 'chef',    '>= 11.14'
-  s.add_dependency 'fauxhai', '~> 3.0', '>= 3.0.1'
+  s.add_dependency 'fauxhai', '~> 3.2.0'
   s.add_dependency 'rspec',   '~> 3.0'
 
   # Development Dependencies

--- a/spec/unit/macros_spec.rb
+++ b/spec/unit/macros_spec.rb
@@ -76,7 +76,7 @@ describe ChefSpec::Macros do
     end
 
     it 'sets the automatic attributes from a JSON data path' do
-      allow(File).to receive(:exists?).with('/path/to/json').and_return(true)
+      allow(File).to receive(:exist?).with('/path/to/json').and_return(true)
       allow(File).to receive(:read).with('/path/to/json').and_return('{ "ipaddress": "1.2.3.4" }')
       node = described_class.stub_node('node.example', path: '/path/to/json')
       expect(node['ipaddress']).to eq('1.2.3.4')


### PR DESCRIPTION
Fauxhai 3.2.0 changes some `File.exists?` calls to `File.exist?`, which
broke a ChefSpec spec that stubbed the former.

- Stub `File.exist?` instead of `File.exists?` in Macros spec.
- Bump Fauxhai version to `~> 3.2.0` in Gemspec.

Fixes #687