### PR TITLE
Loosen the fauxhai dependency

### DIFF
--- a/chefspec.gemspec
+++ b/chefspec.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9'
 
   s.add_dependency 'chef',    '>= 11.14'
-  s.add_dependency 'fauxhai', '~> 3.2.0'
+  s.add_dependency 'fauxhai', '~> 3.2'
   s.add_dependency 'rspec',   '~> 3.0'
 
   # Development Dependencies


### PR DESCRIPTION
This prevents us from having to release new Chefspec when we release new
Fauxhai