### PR TITLE
Allow modifications to node object before converge

### DIFF
--- a/lib/chefspec/solo_runner.rb
+++ b/lib/chefspec/solo_runner.rb
@@ -121,7 +121,7 @@ module ChefSpec
       end
 
       # Allow stubbing/mocking after the cookbook has been compiled but before the converge
-      yield if block_given?
+      yield node if block_given?
 
       @converging = true
       converge_val = @client.converge(@run_context)


### PR DESCRIPTION
Covers the case of modifying attributes after default values have been read on comiplation, but before converging.