### PR TITLE
Ensure that the SoloRunner works in RFC31 world

### DIFF
--- a/lib/chefspec/server_runner.rb
+++ b/lib/chefspec/server_runner.rb
@@ -27,6 +27,7 @@ module ChefSpec
       Chef::Config[:client_name]     = 'chefspec'
       Chef::Config[:node_name]       = 'chefspec'
       Chef::Config[:solo]            = false
+      Chef::Config[:solo_legacy_mode] = false
 
       Chef::Config[:chef_server_url]  = server.url
       Chef::Config[:http_retry_count] = 0

--- a/lib/chefspec/solo_runner.rb
+++ b/lib/chefspec/solo_runner.rb
@@ -79,6 +79,7 @@ module ChefSpec
       Chef::Config[:role_path]       = Array(@options[:role_path])
       Chef::Config[:force_logger]    = true
       Chef::Config[:solo]            = true
+      Chef::Config[:solo_legacy_mode] = true
       Chef::Config[:environment_path] = @options[:environment_path]
 
       yield node if block_given?


### PR DESCRIPTION
Once chef/chef#4919 is merged, chef-solo is local mode by default,
but can be configured into legacy mode.

cc @tas50 @sethvargo