### PR TITLE
Fix up travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ before_install:
   - gem install bundler
 
 rvm:
-  - 2.0.0
   - 2.1
   - 2.2
 
@@ -32,15 +31,24 @@ env:
   - CHEF_VERSION=12.1.1
   - CHEF_VERSION=12.1.0
   - CHEF_VERSION=12.0.3
-  - CHEF_VERSION=11.18.6
-  - CHEF_VERSION=11.18.0
-  - CHEF_VERSION=11.16.4
-  - CHEF_VERSION=11.16.2
-  - CHEF_VERSION=11.16.0
-  - CHEF_VERSION=11.14.6
-  - CHEF_VERSION=11.14.2
 
 matrix:
   fast_finish: true
   allow_failures:
     - env: CHEF_VERSION=master
+  include:
+    - env: CHEF_VERSION=11.18.6
+      rvm: 1.9.3
+    - env: CHEF_VERSION=11.18.0
+      rvm: 1.9.3
+    - env: CHEF_VERSION=11.16.4
+      rvm: 1.9.3
+    - env: CHEF_VERSION=11.16.2
+      rvm: 1.9.3
+    - env: CHEF_VERSION=11.16.0
+      rvm: 1.9.3
+    - env: CHEF_VERSION=11.14.6
+      rvm: 1.9.3
+    - env: CHEF_VERSION=11.14.2
+      rvm: 1.9.3
+


### PR DESCRIPTION
Only run 11 with ruby 1.9, and then remove 2.0 from the matrix

cc @sethvargo @tas50