### PR TITLE
Highlight the need for Ruby2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ What people are saying
 
 Important Notes
 ---------------
-- **ChefSpec 3.0+ requires Ruby 1.9 or higher!**
+- **ChefSpec 3.0+ requires Ruby 2.1 or higher!**
 - **This documentation corresponds to the master branch, which may be unreleased. Please check the README of the latest git tag or the gem's source for your version's documentation!**
 - **Each resource matcher is self-documented using [Yard](http://rubydoc.info/github/sethvargo/chefspec) and has a corresponding aruba test from the [examples directory](https://github.com/sethvargo/chefspec/tree/master/examples).**
 - **ChefSpec aims to maintain compatibility with the two most recent minor versions of Chef.** If you are running an older version of Chef it may work, or you will need to run an older version of ChefSpec.

--- a/chefspec.gemspec
+++ b/chefspec.gemspec
@@ -23,8 +23,8 @@ Gem::Specification.new do |s|
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ['lib']
 
-  # ChefSpec requires Ruby 1.9+
-  s.required_ruby_version = '>= 1.9'
+  # ChefSpec requires Ruby 2.1+
+  s.required_ruby_version = '>= 2.1'
 
   s.add_dependency 'chef',    '>= 11.14'
   s.add_dependency 'fauxhai', '~> 3.2'


### PR DESCRIPTION
ChefSpec depends on chef, through a tilka-wakka.  The version of Chef
which is currently resolved by bundler is a version that requires
Ruby2.1

Thus, ChefSpec requires Ruby2.1 or greater.