### PR TITLE
Upgrade fauxhai to 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,19 +36,4 @@ matrix:
   fast_finish: true
   allow_failures:
     - env: CHEF_VERSION=master
-  include:
-    - env: CHEF_VERSION=11.18.6
-      rvm: 1.9.3
-    - env: CHEF_VERSION=11.18.0
-      rvm: 1.9.3
-    - env: CHEF_VERSION=11.16.4
-      rvm: 1.9.3
-    - env: CHEF_VERSION=11.16.2
-      rvm: 1.9.3
-    - env: CHEF_VERSION=11.16.0
-      rvm: 1.9.3
-    - env: CHEF_VERSION=11.14.6
-      rvm: 1.9.3
-    - env: CHEF_VERSION=11.14.2
-      rvm: 1.9.3
 

--- a/chefspec.gemspec
+++ b/chefspec.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.1'
 
   s.add_dependency 'chef',    '>= 11.14'
-  s.add_dependency 'fauxhai', '~> 3.2'
+  s.add_dependency 'fauxhai', '~> 3.5'
   s.add_dependency 'rspec',   '~> 3.0'
 
   # Development Dependencies

--- a/lib/chefspec/version.rb
+++ b/lib/chefspec/version.rb
@@ -1,3 +1,3 @@
 module ChefSpec
-  VERSION = '4.7.0'
+  VERSION = '5.0.0'
 end


### PR DESCRIPTION
Fauxhai 3.5 adds support for FreeBSD 10.3. Additionally, I've also created https://github.com/customink/fauxhai/pull/234 to fix the root_group on all FreeBSD versions to 'wheel'.