### PR TITLE
Add support for :before timer to NotificationsMatcher and SubscriptionsMatcher

### DIFF
--- a/examples/notifications/recipes/before.rb
+++ b/examples/notifications/recipes/before.rb
@@ -1,0 +1,7 @@
+template '/tmp/notifying_resource' do
+  notifies :restart, 'service[receiving_resource]', :before
+end
+
+service 'receiving_resource' do
+  action :nothing
+end

--- a/examples/notifications/spec/before_spec.rb
+++ b/examples/notifications/spec/before_spec.rb
@@ -1,0 +1,16 @@
+require 'chefspec'
+
+describe 'notifications::before' do
+  let(:chef_run) { ChefSpec::SoloRunner.converge(described_recipe) }
+  let(:template) { chef_run.template('/tmp/notifying_resource') }
+
+  it 'sends a notification to the service' do
+    expect(template).to notify('service[receiving_resource]').before
+    expect(template).to_not notify('service[not_receiving_resource]').before
+  end
+
+  it 'sends the specific notification to the service before' do
+    expect(template).to notify('service[receiving_resource]').to(:restart).before
+    expect(template).to_not notify('service[receiving_resource]').to(:restart).immediately
+  end
+end

--- a/examples/subscribes/recipes/before.rb
+++ b/examples/subscribes/recipes/before.rb
@@ -1,0 +1,5 @@
+template '/tmp/notifying_resource'
+
+service 'receiving_resource' do
+  subscribes :create, 'template[/tmp/notifying_resource]', :before
+end

--- a/examples/subscribes/spec/before_spec.rb
+++ b/examples/subscribes/spec/before_spec.rb
@@ -1,0 +1,16 @@
+require 'chefspec'
+
+describe 'subscribes::before' do
+  let(:chef_run) { ChefSpec::SoloRunner.converge(described_recipe) }
+  let(:service) { chef_run.service('receiving_resource') }
+
+  it 'subscribes to the template creation' do
+    expect(service).to subscribe_to('template[/tmp/notifying_resource]').before
+    expect(service).to_not subscribe_to('template[/tmp/not_notifying_resource]').before
+  end
+
+  it 'subscribes to the specific action on the resource before' do
+    expect(service).to subscribe_to('template[/tmp/notifying_resource]').on(:create).before
+    expect(service).to_not subscribe_to('template[/tmp/notifying_resource]').on(:delete).immediately
+  end
+end

--- a/features/notifications.feature
+++ b/features/notifications.feature
@@ -7,6 +7,7 @@ Feature: The notifications matcher
     * the output should contain "0 failures"
   Examples:
     | Matcher     |
+    | before      |
     | chained     |
     | default     |
     | delayed     |

--- a/features/subscribes.feature
+++ b/features/subscribes.feature
@@ -7,6 +7,7 @@ Feature: The subscribes matcher
     * the output should contain "0 failures"
   Examples:
     | Matcher     |
+    | before      |
     | chained     |
     | default     |
     | delayed     |

--- a/lib/chefspec/matchers/notifications_matcher.rb
+++ b/lib/chefspec/matchers/notifications_matcher.rb
@@ -22,6 +22,8 @@ module ChefSpec::Matchers
           immediate_notifications.any?(&block)
         elsif @delayed
           delayed_notifications.any?(&block)
+        elsif @before
+          before_notifications.any?(&block)
         else
           all_notifications.any?(&block)
         end
@@ -43,11 +45,17 @@ module ChefSpec::Matchers
       self
     end
 
+    def before
+      @before = true
+      self
+    end
+
     def description
       message = %Q{notify "#{@expected_resource_type}[#{@expected_resource_name}]"}
       message << " with action :#{@action}" if @action
       message << " immediately" if @immediately
       message << " delayed" if @delayed
+      message << " before" if @before
       message
     end
 
@@ -57,6 +65,7 @@ module ChefSpec::Matchers
         message << " with action :#{@action}" if @action
         message << " immediately" if @immediately
         message << " delayed" if @delayed
+        message << " before" if @before
         message << ", but did not."
         message << "\n\n"
         message << "Other notifications were:\n\n#{format_notifications}"
@@ -67,6 +76,7 @@ module ChefSpec::Matchers
         message << " with action :#{@action}" if @action
         message << " immediately" if @immediately
         message << " delayed" if @delayed
+        message << " before" if @before
         message << ", but the _something_ you gave me was nil! If you are running a test like:"
         message << "\n\n"
         message << "  expect(_something_).to notify('...')"
@@ -88,7 +98,7 @@ module ChefSpec::Matchers
     private
 
     def all_notifications
-      immediate_notifications + delayed_notifications
+      immediate_notifications + delayed_notifications + before_notifications
     end
 
     def immediate_notifications
@@ -99,6 +109,10 @@ module ChefSpec::Matchers
       @resource.delayed_notifications
     end
 
+    def before_notifications
+      @resource.before_notifications
+    end
+
     def matches_action?(notification)
       return true if @action.nil?
       @action == notification.action.to_sym
@@ -107,7 +121,14 @@ module ChefSpec::Matchers
     def format_notification(notification)
       notifying_resource = notification.notifying_resource
       resource = notification.resource
-      type = notification.notifying_resource.immediate_notifications.include?(notification) ? :immediately : :delayed
+
+      if notifying_resource.immediate_notifications.include?(notification)
+        type = :immediately
+      elsif notifying_resource.before_notifications.include?(notification)
+        type = :before
+      else
+        type = :delayed
+      end
 
       %Q{  "#{notifying_resource.to_s}" notifies "#{resource_name(resource)}[#{resource.name}]" to :#{notification.action}, :#{type}}
     end

--- a/lib/chefspec/matchers/subscribes_matcher.rb
+++ b/lib/chefspec/matchers/subscribes_matcher.rb
@@ -23,6 +23,10 @@ module ChefSpec::Matchers
         @instance.delayed
       end
 
+      if @before
+        @instance.before
+      end
+
       if resource
         runner   = resource.run_context.node.runner
         expected = runner.find_resource(@expected_resource_type, @expected_resource_name)
@@ -45,6 +49,11 @@ module ChefSpec::Matchers
 
     def delayed
       @delayed = true
+      self
+    end
+
+    def before
+      @before = true
       self
     end
 

--- a/spec/unit/matchers/notifications_matcher_spec.rb
+++ b/spec/unit/matchers/notifications_matcher_spec.rb
@@ -10,6 +10,7 @@ describe ChefSpec::Matchers::NotificationsMatcher do
       performed_action?: true,
       immediate_notifications: [],
       delayed_notifications: [],
+      before_notifications: []
     )
   end
 

--- a/spec/unit/matchers/subscribes_matcher_spec.rb
+++ b/spec/unit/matchers/subscribes_matcher_spec.rb
@@ -30,6 +30,7 @@ describe ChefSpec::Matchers::SubscribesMatcher do
         to_s: 'execute[install]',
         immediate_notifications: [],
         delayed_notifications: [],
+        before_notifications: []
       )
     end
 


### PR DESCRIPTION
This now allows assertions like:

```ruby
    expect(template).to notify('service[receiving_resource]').before
```
Fixes issue #679 