### PR TITLE
ensure that render_file always attempts to expand content

### DIFF
--- a/lib/chefspec/matchers/render_file_matcher.rb
+++ b/lib/chefspec/matchers/render_file_matcher.rb
@@ -106,11 +106,11 @@ module ChefSpec::Matchers
     # @return [true, false]
     #
     def matches_content?
-      return true if @expected_content.nil?
-
+      # always render, even if no expected_content is required
       @actual_content = ChefSpec::Renderer.new(@runner, resource).content
 
       return false if @actual_content.nil?
+      return true if @expected_content.nil?
 
       if @expected_content.is_a?(Regexp)
         @actual_content =~ @expected_content


### PR DESCRIPTION
Currently chefspec will not actually render a template unless expected_content is provided. 
This causes examples such as below to give a false sense of security to users who invoke render_file without content matchers

```
expect(chef_run).to render_file('/path/to/some/template_resource')
```