### PR TITLE
data_bag_item secret support

### DIFF
--- a/lib/chefspec/extensions/chef/data_query.rb
+++ b/lib/chefspec/extensions/chef/data_query.rb
@@ -33,8 +33,8 @@ module Chef::DSL::DataQuery
 
   # @see Chef::DSL::DataQuery#data_bag_item
   alias_method :old_data_bag_item, :data_bag_item
-  def data_bag_item(bag, id)
-    return old_data_bag_item(bag, id) unless Chef::Config[:solo]
+  def data_bag_item(bag, id, secret = nil)
+    return old_data_bag_item(bag, id, secret) unless Chef::Config[:solo]
 
     stub = ChefSpec::Stubs::DataBagItemRegistry.stub_for(bag, id)
 


### PR DESCRIPTION
Allows to stub encrypted databags loaded with `data_bag_item`
chef/chef#1853 changed the method signature, so it’s possible to load encrypted data bags using `data_bag_item(bag, item, secret)`.
chefspec didn't reflect the change, so stub_data_bag fails if applied to an encrypted databag.