### PR TITLE
Add scoped_id to cacher keying

### DIFF
--- a/lib/chefspec/cacher.rb
+++ b/lib/chefspec/cacher.rb
@@ -35,8 +35,9 @@ module ChefSpec
 
     def cached(name, &block)
       location = ancestors.first.metadata[:location]
-      unless ancestors.first.metadata[:description].nil? || location.nil?
-        location += ancestors.first.metadata[:description]
+      unless location.nil?
+        location += ancestors.first.metadata[:description] unless ancestors.first.metadata[:description].nil?
+        location += ancestors.first.metadata[:scoped_id] unless ancestors.first.metadata[:scoped_id].nil?
       end
       location ||= ancestors.first.metadata[:parent_example_group][:location]
 

--- a/spec/unit/cacher_spec.rb
+++ b/spec/unit/cacher_spec.rb
@@ -13,8 +13,9 @@ describe ChefSpec::Cacher do
   end
 
   let(:cache) { described_class.class_variable_get(:@@cache) }
+  let(:preserve_cache) { false }
 
-  before(:each) { described_class.class_variable_set(:@@cache, {}) }
+  before(:each) { described_class.class_variable_set(:@@cache, {}) unless preserve_cache }
 
   describe 'cached' do
     it 'lazily defines the results for the cache' do
@@ -38,6 +39,21 @@ describe ChefSpec::Cacher do
             klass.cached(:chef_run) { n }
             expect(klass.new.chef_run).to eq(n)
           end.join
+        end
+      end
+    end
+
+    context 'when example groups are defined by looping' do
+      let(:preserve_cache) { true }
+
+      ['first', 'second', 'third'].each do |iteration|
+        context "on the #{iteration} iteration" do
+          context 'in caching context' do
+            cached(:cached_iteration) { iteration }
+            it 'caches the iteration for this context' do
+              expect(cached_iteration).to eq iteration
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
Add scoped_id to the Cacher key to be more precise in referring to example groups.

This solves cache leaking between example groups that are defined in loops (which subsequently have the same location) and with the same description.

The spec I wrote literally reproduces this case, as I wasn't sure how I could fit it into the mock class (if I should even do that at all).