### PR TITLE
updated the example so as to make it a working example

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ the associated ChefSpec test might look like:
 require 'chefspec'
 
 describe 'example::default' do
-  let(:chef_run) { ChefSpec::SoloRunner.converge(described_recipe) }
+  let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '16.04').converge(described_recipe) }
 
   it 'installs foo' do
     expect(chef_run).to install_package('foo')


### PR DESCRIPTION
Hi,

I am starting to learn chefspec and was using this Readme as a tutorial. However, the example provided was failing with this exception - 

```
Cannot find a resource for apt_update on chefspec version 0.6.1
     # ./spec/default_spec.rb:6:in `block (2 levels) in <top (required)>'
     # ./spec/default_spec.rb:10:in `block (2 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # Chef::Exceptions::NoSuchResourceType:
     #   Cannot find a resource for apt_update on chefspec version 0.6.1
```

I was able to fix this error with the lines updated in this PR. Could you help review this please?

Thanks!