### PR TITLE
Use `Chef::Config[:file_cache_path]` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ RSpec.configure do |config|
   config.environment_path = '/var/environments'
 
   # Specify the path for Chef Solo file cache path (default: nil)
-  config.file_cache_path = '/var/chef/cache'
+  config.file_cache_path = Chef::Config[:file_cache_path]
 
   # Specify the Chef log_level (default: :warn)
   config.log_level = :debug
@@ -120,7 +120,7 @@ ChefSpec::SoloRunner.new(cookbook_path: '/var/my/other/path', role_path: '/var/m
 # This can be overridden by passing the `file_cache_path` option.
 # Note: Resources containing `Chef::Config[:file_cache_path]` in their name or
 # attributes, will fail unless this option is specified.
-ChefSpec::SoloRunner.new(file_cache_path: '/var/chef/cache')
+ChefSpec::SoloRunner.new(file_cache_path: Chef::Config[:file_cache_path])
 
 # Add debug log output
 ChefSpec::SoloRunner.new(log_level: :debug).converge(described_recipe)


### PR DESCRIPTION
# Description
When stubbing the value of `file_cache_path` it is better to use the value of `Chef::Config[:file_cache_path]` rather than `/var/cache/chef`. 

This PR ensures that the value of the `file_cache_path` is same as the value that is returned when the user runs `rspec` regardless of which OS `rspec` is ran on.

Currently stubbing the value to `/var/cache/chef` works, unless you do the `File.join` or interpolation in a variable outside of the resource.

See below:

# Passing Scenario (using `/var/cache/chef`)
```ruby
file File.join(Chef::Config[:file_cache_path], 'myfile') do
  action :create
end
```

```ruby
require 'spec_helper'

describe 'sample_cookbook::default' do
  context 'When all attributes are default, on an unspecified platform' do
    let(:chef_run) do
      runner = ChefSpec::SoloRunner.new(file_cache_path: '/var/chef/cache')
      runner.converge(described_recipe)
    end

    it 'creates `myfile`' do
      expect(chef_run).to create_file(File.join(Chef::Config[:file_cache_path], 'myfile'))
    end
  end
end
```

# Failure Scenario (using `/var/cache/chef`)
```ruby
my_file_path = File.join(Chef::Config[:file_cache_path], 'myfile')

file my_file_path do
  action :create
end
```
```ruby
require 'spec_helper'

describe 'sample_cookbook::default' do
  context 'When all attributes are default, on an unspecified platform' do
    let(:chef_run) do
      runner = ChefSpec::SoloRunner.new(file_cache_path: '/var/chef/cache')
      runner.converge(described_recipe)
    end

    my_file_path = File.join(Chef::Config[:file_cache_path], 'myfile')
    it 'create `myfile`' do
      expect(chef_run).to create_file(my_file_path)
    end
  end
end
```
```
Failures:

  1) sample_cookbook::default When all attributes are default, on an unspecified platform creates `myfile`
     Failure/Error: expect(chef_run).to create_file(my_file_path)

       expected "file[/Users/jerry/.chef/cache/myfile]" with action :create to be in Chef run. Other file resources:

         file[/var/chef/cache/myfile]

     # ./spec/unit/recipes/default_spec.rb:18:in `block (3 levels) in <top (required)>'
```

# Suggested Solution
Setting either of the following allows both scenarios above to pass:
```ruby
  let(:chef_run) do
      runner = ChefSpec::SoloRunner.new(file_cache_path: Chef::Config[:file_cache_path])
      runner.converge(described_recipe)
  end
```
```ruby
RSpec.configure do |config|
  config.file_cache_path = Chef::Config[:file_cache_path]
end
```