### PR TITLE
Allow users to specify ServerRunner data storage type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG for ChefSpec
 
+## Unreleased
+
+IMPROVEMENTS
+
+- Support for in-memory or on-disk ChefZero Servers
+
 ## 5.3.0 (October 29, 2016)
 
 IMPROVEMENTS

--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ RSpec.configure do |config|
 
   # Specify the operating version to mock Ohai data from (default: nil)
   config.version = '14.04'
+
+  # When using ChefSpec::ServerRunner, specify the data storage method (options: in_memory, on_disk; default: in_memory)
+  config.server_runner_data_store = :on_disk
 end
 ```
 
@@ -511,6 +514,12 @@ end
 
 **NOTE** The ChefSpec server is empty at the start of each example to avoid interdependent tests.
 
+### Data Store
+
+The `ServerRunner` has two options for how it will store data: `in_memory` or `on_disk`. The default
+value is `in_memory`. These two options have different performance implications based on your specific
+setup. If you are running into performance problems (slow tests, frequent hanging, etc) with one setting,
+try using the other.
 
 Stubbing
 --------

--- a/features/server_on_disk.feature
+++ b/features/server_on_disk.feature
@@ -1,0 +1,16 @@
+Feature: The ChefSpec server with on-disk storage
+  Background:
+    * I am using the "server" cookbook
+
+  Scenario Outline: Running specs
+    * I successfully run `rspec spec/<Component>_spec.rb --require ../../../features/support/on_disk.rb`
+    * the output should contain "0 failures"
+  Examples:
+    | Component          |
+    | client             |
+    | data_bag           |
+    | environment        |
+    | node               |
+    | render_with_cached |
+    | role               |
+    | search             |

--- a/features/support/on_disk.rb
+++ b/features/support/on_disk.rb
@@ -1,0 +1,7 @@
+# We need to add this setting because for the first test, we haven't had a chance
+# to load the chefspec rspec.rb file, so the first test will fail if we simply
+# try to set it like we would otherwise.
+
+RSpec.configure do |config|
+  config.add_setting :server_runner_data_store, default: :on_disk
+end

--- a/lib/chefspec/rspec.rb
+++ b/lib/chefspec/rspec.rb
@@ -19,4 +19,5 @@ RSpec.configure do |config|
   config.add_setting :path
   config.add_setting :platform
   config.add_setting :version
+  config.add_setting :server_runner_data_store, default: :in_memory
 end

--- a/lib/chefspec/server_methods.rb
+++ b/lib/chefspec/server_methods.rb
@@ -16,6 +16,9 @@ module ChefSpec
 
         # Set a random port so ChefSpec may be run in multiple contexts
         port: port,
+
+        # Set the data store
+        data_store: data_store(RSpec.configuration.server_runner_data_store),
       )
     end
 
@@ -171,6 +174,28 @@ module ChefSpec
       else
         @server.data_store.get(args)
       end
+    end
+
+    #
+    # Generate the DataStore object to be passed in to the ChefZero::Server object
+    #
+    def data_store(option)
+      require "chef_zero/data_store/default_facade"
+
+      store = case option
+              when :in_memory
+                require "chef_zero/data_store/memory_store_v2"
+                ChefZero::DataStore::MemoryStoreV2.new
+              when :on_disk
+                require "tmpdir"
+                require "chef_zero/data_store/raw_file_store"
+                tmpdir = Dir.mktmpdir
+                ChefZero::DataStore::RawFileStore.new(Dir.mktmpdir)
+              else
+                raise ArgumentError, ":#{option} is not a valid server_runner_data_store option. Please use either :in_memory or :on_disk."
+              end
+
+      ChefZero::DataStore::DefaultFacade.new(store, "chef", true)
     end
   end
 end


### PR DESCRIPTION
The ServerRunner is supported by ChefZero::Server, which supports two types of data stores: in-memory and on-disk. These two data stores have different benefits but being able to choose between them will allow some users with different constraints to optimize their experience.

Signed-off-by: Tom Duffield <tom@chef.io>