### PR TITLE
Cleanup server to avoid thread leakage during tests

### DIFF
--- a/lib/chefspec/server_methods.rb
+++ b/lib/chefspec/server_methods.rb
@@ -10,7 +10,7 @@ module ChefSpec
     # @return [ChefZero::Server]
     #
     def server
-      @server ||= ChefZero::Server.new(
+      @@server ||= ChefZero::Server.new(
         # Set the log level from RSpec, defaulting to warn
         log_level:  RSpec.configuration.log_level || :warn,
 
@@ -160,7 +160,7 @@ module ChefSpec
     #   to the server
     #
     def load_data(name, key, data = {})
-      @server.load_data({ key => { name => data } })
+      @@server.load_data({ key => { name => data } })
     end
 
     #
@@ -170,9 +170,9 @@ module ChefSpec
       args.unshift('organizations', 'chef')
 
       if args.size == 3
-        @server.data_store.list(args)
+        @@server.data_store.list(args)
       else
-        @server.data_store.get(args)
+        @@server.data_store.get(args)
       end
     end
 
@@ -189,7 +189,6 @@ module ChefSpec
               when :on_disk
                 require "tmpdir"
                 require "chef_zero/data_store/raw_file_store"
-                tmpdir = Dir.mktmpdir
                 ChefZero::DataStore::RawFileStore.new(Dir.mktmpdir)
               else
                 raise ArgumentError, ":#{option} is not a valid server_runner_data_store option. Please use either :in_memory or :on_disk."


### PR DESCRIPTION
Each time someone calls `ServerRunner.new`, that thread hangs around until all the suites have been run. This can put a lot of pressure on low-memory environments, leading to poor performance. 

Instead, make the Server thread a class variable and clean it up after every test.