### PR TITLE
Use stand-alone ChefZero server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG for ChefSpec
 
+## 5.5.0 (Unreleased)
+
+IMPROVEMENTS
+
+- Improve ServerRunner speed and reduce process hangs by using single stand-alone chef-zero server.
+
+
 ## 5.4.0 (February 9, 2017)
 
 IMPROVEMENTS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 IMPROVEMENTS
 
-- Improve ServerRunner speed and reduce process hangs by using single stand-alone chef-zero server.
-
+- Improve ServerRunner speed and reduce process hangs by using a single stand-alone chef-zero server.
+- Add configuration value to dictate whether cookbooks are re-uploaded before every test context.
 
 ## 5.4.0 (February 9, 2017)
 

--- a/README.md
+++ b/README.md
@@ -92,9 +92,6 @@ RSpec.configure do |config|
 
   # Specify the operating version to mock Ohai data from (default: nil)
   config.version = '14.04'
-
-  # When using ChefSpec::ServerRunner, specify the data storage method (options: in_memory, on_disk; default: in_memory)
-  config.server_runner_data_store = :on_disk
 end
 ```
 
@@ -121,6 +118,23 @@ ChefSpec::SoloRunner.new(log_level: :debug).converge(described_recipe)
 ```
 
 **NOTE** You do not _need_ to specify a platform and version to use ChefSpec. However, some cookbooks may rely on [Ohai](http://github.com/chef/ohai) data that ChefSpec cannot not automatically generate. Specifying the `platform` and `version` keys instructs ChefSpec to load stubbed Ohai attributes from another platform using [fauxhai](https://github.com/customink/fauxhai).
+
+### ChefZero Server
+
+The `ServerRunner` uses a [chef-zero](https://github.com/chef/chef-zero) instance as a stand-in for a full Chef Server. The instance is created at the initiation of the ChefSpec suite and is terminated at its completion. In between each test the state of the ChefZero server is completely reset.
+
+```ruby
+RSpec.configure do |config|
+  # When using ChefSpec::ServerRunner, specify the data storage method (options: in_memory, on_disk; default: in_memory)
+  # If you are in a low-memory environment, setting this value to :on_disk may improve speed and/or reliability.
+  config.server_runner_data_store = :on_disk
+
+  # Whether or not to clear the cookbooks on the ChefZero instance in-between each test (default: true)
+  # For most people, not clearing the cookbooks will drastically improve test execution time. This is a
+  # good option for people who are using chefspec within the context of a single Berksfile or Policyfile.
+  config.server_runner_clear_cookbooks = false
+end
+```
 
 ### Berkshelf
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -20,14 +20,12 @@ Before do
   # RSpec::Runner) removes our configurations :(
   load 'lib/chefspec/rspec.rb'
 
-  # These settings need to be reloaded specific to the way Aruba runs. That
-  # is why they are here instead of in rspec.rb
+  # These settings need to be specified manually here rather than in rspec.rb
+  # because we do not want the zero-server terminating between each run. The
+  # runs happen too quickly in succession the port doesn't have time to get reset.
   RSpec.configure do |config|
     config.before(:suite) { ChefSpec::ZeroServer.setup! }
-    config.after(:each) do
-      # We need to reset not only the data but the cookbooks as well
-      ChefSpec::ZeroServer.reset!({ clear_cookbooks: true})
-    end
+    config.after(:each) { ChefSpec::ZeroServer.reset! }
   end
 
   # Use a temporary directory to suppress Travis warnings

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -20,6 +20,16 @@ Before do
   # RSpec::Runner) removes our configurations :(
   load 'lib/chefspec/rspec.rb'
 
+  # These settings need to be reloaded specific to the way Aruba runs. That
+  # is why they are here instead of in rspec.rb
+  RSpec.configure do |config|
+    config.before(:suite) { ChefSpec::ZeroServer.setup! }
+    config.after(:each) do
+      # We need to reset not only the data but the cookbooks as well
+      ChefSpec::ZeroServer.reset!({ clear_cookbooks: true})
+    end
+  end
+
   # Use a temporary directory to suppress Travis warnings
   @dirs = [Dir.mktmpdir]
 end

--- a/lib/chefspec/rspec.rb
+++ b/lib/chefspec/rspec.rb
@@ -20,4 +20,5 @@ RSpec.configure do |config|
   config.add_setting :platform
   config.add_setting :version
   config.add_setting :server_runner_data_store, default: :in_memory
+  config.add_setting :server_runner_clear_cookbooks, default: true
 end

--- a/lib/chefspec/server_methods.rb
+++ b/lib/chefspec/server_methods.rb
@@ -10,16 +10,7 @@ module ChefSpec
     # @return [ChefZero::Server]
     #
     def server
-      @server ||= ChefZero::Server.new(
-        # Set the log level from RSpec, defaulting to warn
-        log_level:  RSpec.configuration.log_level || :warn,
-
-        # Set a random port so ChefSpec may be run in multiple contexts
-        port: port,
-
-        # Set the data store
-        data_store: data_store(RSpec.configuration.server_runner_data_store),
-      )
+      ChefSpec::ZeroServer.server
     end
 
     #
@@ -160,7 +151,7 @@ module ChefSpec
     #   to the server
     #
     def load_data(name, key, data = {})
-      @server.load_data({ key => { name => data } })
+      server.load_data({ key => { name => data } })
     end
 
     #
@@ -170,31 +161,10 @@ module ChefSpec
       args.unshift('organizations', 'chef')
 
       if args.size == 3
-        @server.data_store.list(args)
+        server.data_store.list(args)
       else
-        @server.data_store.get(args)
+        server.data_store.get(args)
       end
-    end
-
-    #
-    # Generate the DataStore object to be passed in to the ChefZero::Server object
-    #
-    def data_store(option)
-      require "chef_zero/data_store/default_facade"
-
-      store = case option
-              when :in_memory
-                require "chef_zero/data_store/memory_store_v2"
-                ChefZero::DataStore::MemoryStoreV2.new
-              when :on_disk
-                require "tmpdir"
-                require "chef_zero/data_store/raw_file_store"
-                ChefZero::DataStore::RawFileStore.new(Dir.mktmpdir)
-              else
-                raise ArgumentError, ":#{option} is not a valid server_runner_data_store option. Please use either :in_memory or :on_disk."
-              end
-
-      ChefZero::DataStore::DefaultFacade.new(store, "chef", true)
     end
   end
 end

--- a/lib/chefspec/server_methods.rb
+++ b/lib/chefspec/server_methods.rb
@@ -151,7 +151,7 @@ module ChefSpec
     #   to the server
     #
     def load_data(name, key, data = {})
-      server.load_data({ key => { name => data } })
+      ChefSpec::ZeroServer.load_data(name, key, data)
     end
 
     #

--- a/lib/chefspec/server_runner.rb
+++ b/lib/chefspec/server_runner.rb
@@ -1,7 +1,7 @@
-require 'chef_zero/server'
 require 'chef/cookbook_loader'
 require 'chef/cookbook_uploader'
 
+require_relative 'zero_server'
 require_relative 'file_cache_path_proxy'
 require_relative 'server_methods'
 require_relative 'solo_runner'
@@ -31,10 +31,6 @@ module ChefSpec
 
       Chef::Config[:chef_server_url]  = server.url
       Chef::Config[:http_retry_count] = 0
-
-      # Start the Chef Zero instance in the background
-      server.start_background
-      at_exit { server.stop if server.running? }
 
       # Unlike the SoloRunner, the node AND server object are yielded for
       # customization
@@ -92,21 +88,6 @@ module ChefSpec
       File.open(path, 'wb') { |f| f.write(ChefZero::PRIVATE_KEY) }
       at_exit { FileUtils.rm_rf(tmp) }
       path
-    end
-
-    #
-    # A randomly assigned, open port for run the Chef Zero server.
-    #
-    # @return [Fixnum]
-    #
-    def port
-      return @port if @port
-
-      @server = TCPServer.new('127.0.0.1', 0)
-      @port   = @server.addr[1].to_i
-      @server.close
-
-      return @port
     end
   end
 end

--- a/lib/chefspec/server_runner.rb
+++ b/lib/chefspec/server_runner.rb
@@ -37,31 +37,10 @@ module ChefSpec
       yield node, self if block_given?
     end
 
-    #
-    # Upload the cookbooks to the Chef Server.
-    #
-    def upload_cookbooks!
-      loader = Chef::CookbookLoader.new(Chef::Config[:cookbook_path])
-      loader.load_cookbooks
-      cookbook_uploader_for(loader).upload_cookbooks
-    end
-
-    #
-    # The uploader for the cookbooks.
-    #
-    # @param [Chef::CookbookLoader] loader
-    #   the Chef cookbook loader
-    #
-    # @return [Chef::CookbookUploader]
-    #
-    def cookbook_uploader_for(loader)
-      Chef::CookbookUploader.new(loader.cookbooks)
-    end
-
     # @see (SoloRunner#converge)
     def converge(*recipe_names)
-      upload_cookbooks!
-
+      ChefSpec::ZeroServer.upload_cookbooks!
+      
       super do
         yield if block_given?
 

--- a/lib/chefspec/server_runner.rb
+++ b/lib/chefspec/server_runner.rb
@@ -40,7 +40,7 @@ module ChefSpec
     # @see (SoloRunner#converge)
     def converge(*recipe_names)
       ChefSpec::ZeroServer.upload_cookbooks!
-      
+
       super do
         yield if block_given?
 

--- a/lib/chefspec/zero_server.rb
+++ b/lib/chefspec/zero_server.rb
@@ -34,11 +34,13 @@ module ChefSpec
     #
     # Remove all the data we just loaded from the ChefZero server
     #
-    def reset!(opts = {})
-      if opts[:clear_cookbooks]
+    def reset!
+      if RSpec.configuration.server_runner_clear_cookbooks
         @server.clear_data
         @cookbooks_uploaded = false
       else
+        # If we don't want to do a full clear, iterate through each value that we
+        # set and manually remove it.
         @data_loaded.each do |key, names|
           if key == "data"
             names.each { |n| @server.data_store.delete_dir(["organizations", "chef", key, n]) }
@@ -89,7 +91,7 @@ module ChefSpec
     def load_data(name, key, data)
       @data_loaded[key] ||= []
       @data_loaded[key] << name
-      server.load_data({ key => { name => data } })
+      @server.load_data({ key => { name => data } })
     end
 
     private

--- a/lib/chefspec/zero_server.rb
+++ b/lib/chefspec/zero_server.rb
@@ -1,0 +1,75 @@
+require 'chef_zero/server'
+
+module ChefSpec
+  # Rather than create a ChefZero instance per test case, simply create one
+  # ChefZero instance and reset it for every test case.
+  class ZeroServer
+    class << self
+      extend Forwardable
+      def_delegators :instance, :setup!, :teardown!, :reset!, :server
+    end
+
+    include Singleton
+
+    # Create the ChefZero Server
+    def initialize
+      @server ||= ChefZero::Server.new(
+        # Set the log level from RSpec, defaulting to warn
+        log_level:  RSpec.configuration.log_level || :warn,
+
+        # Set the data store
+        data_store: data_store(RSpec.configuration.server_runner_data_store),
+      )
+    end
+
+    # Start the ChefZero Server
+    def setup!
+      @server.start_background
+    end
+
+    # Remove all the non-cookbook entities from the ChefZero Server
+    def reset!
+      @server.clear_data
+    end
+
+    # Teardown the ChefZero Server
+    def teardown!
+      @server.stop if @server.running?
+    end
+
+    # The URL for the ChefZero Server
+    def server
+      @server
+    end
+
+    private
+
+    #
+    # Generate the DataStore object to be passed in to the ChefZero::Server object
+    #
+    def data_store(option)
+      require "chef_zero/data_store/default_facade"
+
+      store = case option
+              when :in_memory
+                require "chef_zero/data_store/memory_store_v2"
+                ChefZero::DataStore::MemoryStoreV2.new
+              when :on_disk
+                require "tmpdir"
+                require "chef_zero/data_store/raw_file_store"
+                tmpdir = Dir.mktmpdir
+                ChefZero::DataStore::RawFileStore.new(Dir.mktmpdir)
+              else
+                raise ArgumentError, ":#{option} is not a valid server_runner_data_store option. Please use either :in_memory or :on_disk."
+              end
+
+      ChefZero::DataStore::DefaultFacade.new(store, "chef", true)
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.before(:suite) { ChefSpec::ZeroServer.setup! }
+  config.after(:each) { ChefSpec::ZeroServer.reset! }
+  config.after(:suite)  { ChefSpec::ZeroServer.teardown! }
+end

--- a/lib/chefspec/zero_server.rb
+++ b/lib/chefspec/zero_server.rb
@@ -28,16 +28,23 @@ module ChefSpec
     # Start the ChefZero Server
     #
     def setup!
-      @server.start_background
+      @server.start_background unless @server.running?
     end
 
     #
     # Remove all the data we just loaded from the ChefZero server
     #
-    def reset!
-      @data_loaded.each do |key, names|
-        names.each do |name|
-          @server.data_store.delete(["organizations", "chef", key, name])
+    def reset!(opts = {})
+      if opts[:clear_cookbooks]
+        @server.clear_data
+        @cookbooks_uploaded = false
+      else
+        @data_loaded.each do |key, names|
+          if key == "data"
+            names.each { |n| @server.data_store.delete_dir(["organizations", "chef", key, n]) }
+          else
+            names.each { |n| @server.data_store.delete(["organizations", "chef", key, n]) }
+          end
         end
       end
       @data_loaded = {}


### PR DESCRIPTION
Rather than create one chef-zero server per test context, it would improve speed (and help address the near constant hangs reported in #784) if we created a chef-zero instance at the beginning of the test suite, and then just reset it's state after each test context. 

Additionally, rather than uploading the cookbooks for every test, we can save a lot of time by just uploading the cookbooks once. While the default behavior remains the same, by specifying the `server_runner_clear_cookbooks = false` in your RSpec configuration, you can save a lot of time by not re-uploading the cookbooks every time. 