### PR TITLE
Force use_policyfile to false for SoloRunner

### DIFF
--- a/lib/chefspec/solo_runner.rb
+++ b/lib/chefspec/solo_runner.rb
@@ -80,6 +80,7 @@ module ChefSpec
       Chef::Config[:force_logger]    = true
       Chef::Config[:solo]            = true
       Chef::Config[:solo_legacy_mode] = true
+      Chef::Config[:use_policyfile]  = false
       Chef::Config[:environment_path] = @options[:environment_path]
 
       yield node if block_given?

--- a/spec/unit/solo_runner_spec.rb
+++ b/spec/unit/solo_runner_spec.rb
@@ -70,6 +70,7 @@ describe ChefSpec::SoloRunner do
       expect(Chef::Config.force_logger).to be_truthy
       expect(Chef::Config.no_lazy_load).to be_truthy
       expect(Chef::Config.solo).to be_truthy
+      expect(Chef::Config.use_policyfile).to be_falsey
     end
 
     it 'yields a block to set node attributes' do


### PR DESCRIPTION
In some cases, when ChefConfig loads a workstation config that happens
to contain `use_policyfile true`, nothing we can do will overwrite it.
This avoids that whole mess by just forcing use_policyfile to false
since it's not supported anyways.

Signed-off-by: Tom Duffield <tom@chef.io>