### PR TITLE
Avoid deprecation warnings & update platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Values specified at the initialization of a "Runner" merge and take precedence o
 ChefSpec::SoloRunner.new(version: '16.04')
 
 # Use a different operating system platform and version
-ChefSpec::SoloRunner.new(platform: 'centos', version: '7.2.1511')
+ChefSpec::SoloRunner.new(platform: 'centos', version: '7.3.1611')
 
 # Specify a different cookbook_path
 ChefSpec::SoloRunner.new(cookbook_path: '/var/my/other/path', role_path: '/var/my/roles')
@@ -503,7 +503,7 @@ end
 You may also use the `stub_node` macro, which will create a new `Chef::Node` object and accepts the same parameters as the Chef Runner and a Fauxhai object:
 
 ```ruby
-www = stub_node(platform: 'ubuntu', version: '12.04') do |node|
+www = stub_node(platform: 'ubuntu', version: '16.04') do |node|
         node.normal['attribute'] = 'value'
       end
 

--- a/examples/batch/recipes/run.rb
+++ b/examples/batch/recipes/run.rb
@@ -7,7 +7,3 @@ end
 batch 'with_attributes' do
   flags '-f'
 end
-
-batch 'specifying the identity attribute' do
-  command 'identity_attribute'
-end

--- a/examples/batch/spec/run_spec.rb
+++ b/examples/batch/spec/run_spec.rb
@@ -19,8 +19,4 @@ describe 'batch::run' do
     expect(chef_run).to run_batch('with_attributes').with(flags: '-f')
     expect(chef_run).to_not run_batch('with_attributes').with(flags: '-x')
   end
-
-  it 'runs a batch when specifying the identity attribute' do
-    expect(chef_run).to run_batch('identity_attribute')
-  end
 end

--- a/examples/bff_package/spec/install_spec.rb
+++ b/examples/bff_package/spec/install_spec.rb
@@ -1,7 +1,7 @@
 require 'chefspec'
 
 describe 'bff_package::install' do
-  let(:chef_run) { ChefSpec::SoloRunner.converge(described_recipe) }
+  let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'aix', version: '7.1').converge(described_recipe) }
 
   it 'installs a bff_package with the default action' do
     expect(chef_run).to install_bff_package('default_action')

--- a/examples/bff_package/spec/purge_spec.rb
+++ b/examples/bff_package/spec/purge_spec.rb
@@ -1,7 +1,7 @@
 require 'chefspec'
 
 describe 'bff_package::purge' do
-  let(:chef_run) { ChefSpec::SoloRunner.converge(described_recipe) }
+  let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'aix', version: '7.1').converge(described_recipe) }
 
   it 'purges a bff_package with an explicit action' do
     expect(chef_run).to purge_bff_package('explicit_action')

--- a/examples/bff_package/spec/remove_spec.rb
+++ b/examples/bff_package/spec/remove_spec.rb
@@ -1,7 +1,7 @@
 require 'chefspec'
 
 describe 'bff_package::remove' do
-  let(:chef_run) { ChefSpec::SoloRunner.converge(described_recipe) }
+  let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'aix', version: '7.1').converge(described_recipe) }
 
   it 'removes a bff_package with an explicit action' do
     expect(chef_run).to remove_bff_package('explicit_action')

--- a/examples/bff_package/spec/upgrade_spec.rb
+++ b/examples/bff_package/spec/upgrade_spec.rb
@@ -1,7 +1,7 @@
 require 'chefspec'
 
 describe 'bff_package::upgrade' do
-  let(:chef_run) { ChefSpec::SoloRunner.converge(described_recipe) }
+  let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'aix', version: '7.1').converge(described_recipe) }
 
   it 'upgrades a bff_package with an explicit action' do
     expect(chef_run).to upgrade_bff_package('explicit_action')

--- a/examples/freebsd_package/spec/install_spec.rb
+++ b/examples/freebsd_package/spec/install_spec.rb
@@ -2,7 +2,7 @@ require 'chefspec'
 
 describe 'freebsd_package::install' do
   let(:chef_run) do
-    ChefSpec::ServerRunner.new(platform: 'freebsd', version: '10.3')
+    ChefSpec::ServerRunner.new(platform: 'freebsd', version: '11.0')
                           .converge(described_recipe)
   end
 

--- a/examples/freebsd_package/spec/remove_spec.rb
+++ b/examples/freebsd_package/spec/remove_spec.rb
@@ -2,7 +2,7 @@ require 'chefspec'
 
 describe 'freebsd_package::remove' do
   let(:chef_run) do
-    ChefSpec::ServerRunner.new(platform: 'freebsd', version: '10.3')
+    ChefSpec::ServerRunner.new(platform: 'freebsd', version: '11.0')
                           .converge(described_recipe)
   end
 

--- a/examples/homebrew_package/spec/install_spec.rb
+++ b/examples/homebrew_package/spec/install_spec.rb
@@ -1,7 +1,7 @@
 require 'chefspec'
 
 describe 'homebrew_package::install' do
-  let(:chef_run) { ChefSpec::SoloRunner.converge(described_recipe) }
+  let(:chef_run) { ChefSpec::ServerRunner.new(platform: 'mac_os_x', version: '10.12').converge(described_recipe) }
 
   it 'installs a homebrew_package with the default action' do
     expect(chef_run).to install_homebrew_package('default_action')

--- a/examples/homebrew_package/spec/purge_spec.rb
+++ b/examples/homebrew_package/spec/purge_spec.rb
@@ -1,7 +1,7 @@
 require 'chefspec'
 
 describe 'homebrew_package::purge' do
-  let(:chef_run) { ChefSpec::SoloRunner.converge(described_recipe) }
+  let(:chef_run) { ChefSpec::ServerRunner.new(platform: 'mac_os_x', version: '10.12').converge(described_recipe) }
 
   it 'purges a homebrew_package with an explicit action' do
     expect(chef_run).to purge_homebrew_package('explicit_action')

--- a/examples/homebrew_package/spec/remove_spec.rb
+++ b/examples/homebrew_package/spec/remove_spec.rb
@@ -1,7 +1,7 @@
 require 'chefspec'
 
 describe 'homebrew_package::remove' do
-  let(:chef_run) { ChefSpec::SoloRunner.converge(described_recipe) }
+  let(:chef_run) { ChefSpec::ServerRunner.new(platform: 'mac_os_x', version: '10.12').converge(described_recipe) }
 
   it 'removes a homebrew_package with an explicit action' do
     expect(chef_run).to remove_homebrew_package('explicit_action')

--- a/examples/homebrew_package/spec/upgrade_spec.rb
+++ b/examples/homebrew_package/spec/upgrade_spec.rb
@@ -1,7 +1,7 @@
 require 'chefspec'
 
 describe 'homebrew_package::upgrade' do
-  let(:chef_run) { ChefSpec::SoloRunner.converge(described_recipe) }
+  let(:chef_run) { ChefSpec::ServerRunner.new(platform: 'mac_os_x', version: '10.12').converge(described_recipe) }
 
   it 'upgrades a homebrew_package with an explicit action' do
     expect(chef_run).to upgrade_homebrew_package('explicit_action')

--- a/examples/launchd/spec/create_if_missing_spec.rb
+++ b/examples/launchd/spec/create_if_missing_spec.rb
@@ -1,7 +1,7 @@
 require 'chefspec'
 
 describe 'launchd::create_if_missing' do
-  let(:chef_run) { ChefSpec::ServerRunner.new(platform: 'mac_os_x', version: '10.11.1').converge(described_recipe) }
+  let(:chef_run) { ChefSpec::ServerRunner.new(platform: 'mac_os_x', version: '10.12').converge(described_recipe) }
 
   it 'creates a launchd daemon if missing with an explicit action' do
     expect(chef_run).to create_if_missing_launchd('explicit_action')

--- a/examples/launchd/spec/create_spec.rb
+++ b/examples/launchd/spec/create_spec.rb
@@ -1,7 +1,7 @@
 require 'chefspec'
 
 describe 'launchd::create' do
-  let(:chef_run) { ChefSpec::ServerRunner.new(platform: 'mac_os_x', version: '10.11.1').converge(described_recipe) }
+  let(:chef_run) { ChefSpec::ServerRunner.new(platform: 'mac_os_x', version: '10.12').converge(described_recipe) }
 
   it 'creates a launchd daemon with an explicit action' do
     expect(chef_run).to create_launchd('explicit_action')

--- a/examples/launchd/spec/delete_spec.rb
+++ b/examples/launchd/spec/delete_spec.rb
@@ -1,7 +1,7 @@
 require 'chefspec'
 
 describe 'launchd::delete' do
-  let(:chef_run) { ChefSpec::ServerRunner.new(platform: 'mac_os_x', version: '10.11.1').converge(described_recipe) }
+  let(:chef_run) { ChefSpec::ServerRunner.new(platform: 'mac_os_x', version: '10.12').converge(described_recipe) }
 
   it 'deletes a launchd with an explicit action' do
     expect(chef_run).to delete_launchd('explicit_action')

--- a/examples/launchd/spec/disable_spec.rb
+++ b/examples/launchd/spec/disable_spec.rb
@@ -1,7 +1,7 @@
 require 'chefspec'
 
 describe 'launchd::disable' do
-  let(:chef_run) { ChefSpec::ServerRunner.new(platform: 'mac_os_x', version: '10.11.1').converge(described_recipe) }
+  let(:chef_run) { ChefSpec::ServerRunner.new(platform: 'mac_os_x', version: '10.12').converge(described_recipe) }
 
   it 'disables a launchd daemon with an explicit action' do
     expect(chef_run).to disable_launchd('explicit_action')

--- a/examples/launchd/spec/enable_spec.rb
+++ b/examples/launchd/spec/enable_spec.rb
@@ -1,7 +1,7 @@
 require 'chefspec'
 
 describe 'launchd::enable' do
-  let(:chef_run) { ChefSpec::ServerRunner.new(platform: 'mac_os_x', version: '10.11.1').converge(described_recipe) }
+  let(:chef_run) { ChefSpec::ServerRunner.new(platform: 'mac_os_x', version: '10.12').converge(described_recipe) }
 
   it 'enables a launchd daemon with an explicit action' do
     expect(chef_run).to enable_launchd('explicit_action')

--- a/examples/macports_package/spec/install_spec.rb
+++ b/examples/macports_package/spec/install_spec.rb
@@ -1,7 +1,7 @@
 require 'chefspec'
 
 describe 'macports_package::install' do
-  let(:chef_run) { ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '16.04').converge(described_recipe) }
+  let(:chef_run) { ChefSpec::ServerRunner.new(platform: 'mac_os_x', version: '10.12').converge(described_recipe) }
 
   it 'installs a macports_package with the default action' do
     expect(chef_run).to install_macports_package('default_action')

--- a/examples/macports_package/spec/purge_spec.rb
+++ b/examples/macports_package/spec/purge_spec.rb
@@ -1,7 +1,7 @@
 require 'chefspec'
 
 describe 'macports_package::purge' do
-  let(:chef_run) { ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '16.04').converge(described_recipe) }
+  let(:chef_run) { ChefSpec::ServerRunner.new(platform: 'mac_os_x', version: '10.12').converge(described_recipe) }
 
   it 'purges a macports_package with an explicit action' do
     expect(chef_run).to purge_macports_package('explicit_action')

--- a/examples/macports_package/spec/remove_spec.rb
+++ b/examples/macports_package/spec/remove_spec.rb
@@ -1,7 +1,7 @@
 require 'chefspec'
 
 describe 'macports_package::remove' do
-  let(:chef_run) { ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '16.04').converge(described_recipe) }
+  let(:chef_run) { ChefSpec::ServerRunner.new(platform: 'mac_os_x', version: '10.12').converge(described_recipe) }
 
   it 'removes a macports_package with an explicit action' do
     expect(chef_run).to remove_macports_package('explicit_action')

--- a/examples/macports_package/spec/upgrade_spec.rb
+++ b/examples/macports_package/spec/upgrade_spec.rb
@@ -1,7 +1,7 @@
 require 'chefspec'
 
 describe 'macports_package::upgrade' do
-  let(:chef_run) { ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '16.04').converge(described_recipe) }
+  let(:chef_run) { ChefSpec::ServerRunner.new(platform: 'mac_os_x', version: '10.12').converge(described_recipe) }
 
   it 'upgrades a macports_package with an explicit action' do
     expect(chef_run).to upgrade_macports_package('explicit_action')

--- a/examples/openbsd_package/spec/install_spec.rb
+++ b/examples/openbsd_package/spec/install_spec.rb
@@ -1,7 +1,7 @@
 require 'chefspec'
 
 describe 'openbsd_package::install' do
-  let(:chef_run) { ChefSpec::SoloRunner.converge(described_recipe) }
+  let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'openbsd', version: '5.4').converge(described_recipe) }
 
   it 'installs a openbsd_package with the default action' do
     expect(chef_run).to install_openbsd_package('default_action')

--- a/examples/openbsd_package/spec/purge_spec.rb
+++ b/examples/openbsd_package/spec/purge_spec.rb
@@ -1,7 +1,7 @@
 require 'chefspec'
 
 describe 'openbsd_package::purge' do
-  let(:chef_run) { ChefSpec::SoloRunner.converge(described_recipe) }
+  let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'openbsd', version: '5.4').converge(described_recipe) }
 
   it 'purges a openbsd_package with an explicit action' do
     expect(chef_run).to purge_openbsd_package('explicit_action')

--- a/examples/openbsd_package/spec/remove_spec.rb
+++ b/examples/openbsd_package/spec/remove_spec.rb
@@ -1,7 +1,7 @@
 require 'chefspec'
 
 describe 'openbsd_package::remove' do
-  let(:chef_run) { ChefSpec::SoloRunner.converge(described_recipe) }
+  let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'openbsd', version: '5.4').converge(described_recipe) }
 
   it 'removes a openbsd_package with an explicit action' do
     expect(chef_run).to remove_openbsd_package('explicit_action')

--- a/examples/openbsd_package/spec/upgrade_spec.rb
+++ b/examples/openbsd_package/spec/upgrade_spec.rb
@@ -1,7 +1,7 @@
 require 'chefspec'
 
 describe 'openbsd_package::upgrade' do
-  let(:chef_run) { ChefSpec::SoloRunner.converge(described_recipe) }
+  let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'openbsd', version: '5.4').converge(described_recipe) }
 
   it 'upgrades a openbsd_package with an explicit action' do
     expect(chef_run).to upgrade_openbsd_package('explicit_action')

--- a/examples/osx_profile/spec/install_spec.rb
+++ b/examples/osx_profile/spec/install_spec.rb
@@ -1,7 +1,7 @@
 require 'chefspec'
 
 describe 'osx_profile::install' do
-  let(:chef_run) { ChefSpec::ServerRunner.new(platform: 'mac_os_x', version: '10.11.1').converge(described_recipe) }
+  let(:chef_run) { ChefSpec::ServerRunner.new(platform: 'mac_os_x', version: '10.12').converge(described_recipe) }
 
   it 'installs an osx_profile with an explicit action' do
     expect(chef_run).to install_osx_profile('explicit_action')

--- a/examples/osx_profile/spec/remove_spec.rb
+++ b/examples/osx_profile/spec/remove_spec.rb
@@ -1,7 +1,7 @@
 require 'chefspec'
 
 describe 'osx_profile::remove' do
-  let(:chef_run) { ChefSpec::ServerRunner.new(platform: 'mac_os_x', version: '10.11.1').converge(described_recipe) }
+  let(:chef_run) { ChefSpec::ServerRunner.new(platform: 'mac_os_x', version: '10.12').converge(described_recipe) }
 
   it 'removes an osx_profile from the resource name' do
     expect(chef_run).to remove_osx_profile('specifying profile')

--- a/examples/pacman_package/spec/install_spec.rb
+++ b/examples/pacman_package/spec/install_spec.rb
@@ -2,7 +2,7 @@ require 'chefspec'
 
 describe 'pacman_package::install' do
   let(:chef_run) do
-    ChefSpec::ServerRunner.new(platform: 'arch', version: '4.5.4-1-ARCH')
+    ChefSpec::ServerRunner.new(platform: 'arch', version: '4.9.11-1-ARCH')
                           .converge(described_recipe)
   end
 

--- a/examples/pacman_package/spec/purge_spec.rb
+++ b/examples/pacman_package/spec/purge_spec.rb
@@ -2,7 +2,7 @@ require 'chefspec'
 
 describe 'pacman_package::purge' do
   let(:chef_run) do
-    ChefSpec::ServerRunner.new(platform: 'arch', version: '4.5.4-1-ARCH')
+    ChefSpec::ServerRunner.new(platform: 'arch', version: '4.9.11-1-ARCH')
                           .converge(described_recipe)
   end
 

--- a/examples/pacman_package/spec/remove_spec.rb
+++ b/examples/pacman_package/spec/remove_spec.rb
@@ -2,7 +2,7 @@ require 'chefspec'
 
 describe 'pacman_package::remove' do
   let(:chef_run) do
-    ChefSpec::ServerRunner.new(platform: 'arch', version: '4.5.4-1-ARCH')
+    ChefSpec::ServerRunner.new(platform: 'arch', version: '4.9.11-1-ARCH')
                           .converge(described_recipe)
   end
 

--- a/examples/pacman_package/spec/upgrade_spec.rb
+++ b/examples/pacman_package/spec/upgrade_spec.rb
@@ -2,7 +2,7 @@ require 'chefspec'
 
 describe 'pacman_package::upgrade' do
   let(:chef_run) do
-    ChefSpec::ServerRunner.new(platform: 'arch', version: '4.5.4-1-ARCH')
+    ChefSpec::ServerRunner.new(platform: 'arch', version: '4.9.11-1-ARCH')
                           .converge(described_recipe)
   end
 

--- a/examples/paludis_package/spec/install_spec.rb
+++ b/examples/paludis_package/spec/install_spec.rb
@@ -1,7 +1,7 @@
 require 'chefspec'
 
 describe 'paludis_package::install' do
-  let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '16.04').converge(described_recipe) }
+  let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'gentoo', version: '2.2').converge(described_recipe) }
 
   it 'installs a paludis_package with the default action' do
     expect(chef_run).to install_paludis_package('default_action')

--- a/examples/paludis_package/spec/purge_spec.rb
+++ b/examples/paludis_package/spec/purge_spec.rb
@@ -1,7 +1,7 @@
 require 'chefspec'
 
 describe 'paludis_package::purge' do
-  let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '16.04').converge(described_recipe) }
+  let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'gentoo', version: '2.2').converge(described_recipe) }
 
   it 'purges a paludis_package with an explicit action' do
     expect(chef_run).to purge_paludis_package('explicit_action')

--- a/examples/paludis_package/spec/remove_spec.rb
+++ b/examples/paludis_package/spec/remove_spec.rb
@@ -1,7 +1,7 @@
 require 'chefspec'
 
 describe 'paludis_package::remove' do
-  let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '16.04').converge(described_recipe) }
+  let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'gentoo', version: '2.2').converge(described_recipe) }
 
   it 'removes a paludis_package with an explicit action' do
     expect(chef_run).to remove_paludis_package('explicit_action')

--- a/examples/paludis_package/spec/upgrade_spec.rb
+++ b/examples/paludis_package/spec/upgrade_spec.rb
@@ -1,7 +1,7 @@
 require 'chefspec'
 
 describe 'paludis_package::upgrade' do
-  let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '16.04').converge(described_recipe) }
+  let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'gentoo', version: '2.2').converge(described_recipe) }
 
   it 'upgrades a paludis_package with an explicit action' do
     expect(chef_run).to upgrade_paludis_package('explicit_action')

--- a/examples/powershell_script/recipes/run.rb
+++ b/examples/powershell_script/recipes/run.rb
@@ -7,7 +7,3 @@ end
 powershell_script 'with_attributes' do
   flags '--flags'
 end
-
-powershell_script 'specifying the identity attribute' do
-  command 'identity_attribute'
-end

--- a/examples/powershell_script/spec/run_spec.rb
+++ b/examples/powershell_script/spec/run_spec.rb
@@ -19,8 +19,4 @@ describe 'powershell_script::run' do
     expect(chef_run).to run_powershell_script('with_attributes').with(flags: '--flags')
     expect(chef_run).to_not run_powershell_script('with_attributes').with(flags: '--not-flags')
   end
-
-  it 'runs a powershell_script when specifying the identity attribute' do
-    expect(chef_run).to run_powershell_script('identity_attribute')
-  end
 end

--- a/examples/roles/spec/default_spec.rb
+++ b/examples/roles/spec/default_spec.rb
@@ -1,7 +1,7 @@
 require 'chefspec'
 
 describe 'roles' do
-  let(:chef_run) { ChefSpec::SoloRunner.converge('role[role]') }
+  let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '16.04').converge('role[role]') }
 
   it 'expands the run_list' do
     expect(chef_run).to include_recipe('roles::default')

--- a/examples/rpm_package/spec/install_spec.rb
+++ b/examples/rpm_package/spec/install_spec.rb
@@ -2,7 +2,7 @@ require 'chefspec'
 
 describe 'rpm_package::install' do
   let(:chef_run) do
-    ChefSpec::ServerRunner.new(platform: 'centos', version: '7.2.1511')
+    ChefSpec::ServerRunner.new(platform: 'centos', version: '7.3.1611')
                           .converge(described_recipe)
   end
 

--- a/examples/rpm_package/spec/remove_spec.rb
+++ b/examples/rpm_package/spec/remove_spec.rb
@@ -2,7 +2,7 @@ require 'chefspec'
 
 describe 'rpm_package::remove' do
   let(:chef_run) do
-    ChefSpec::ServerRunner.new(platform: 'centos', version: '7.2.1511')
+    ChefSpec::ServerRunner.new(platform: 'centos', version: '7.3.1611')
                           .converge(described_recipe)
   end
 

--- a/examples/rpm_package/spec/upgrade_spec.rb
+++ b/examples/rpm_package/spec/upgrade_spec.rb
@@ -2,7 +2,7 @@ require 'chefspec'
 
 describe 'rpm_package::upgrade' do
   let(:chef_run) do
-    ChefSpec::ServerRunner.new(platform: 'centos', version: '7.2.1511')
+    ChefSpec::ServerRunner.new(platform: 'centos', version: '7.3.1611')
                           .converge(described_recipe)
   end
 

--- a/examples/ruby_block/spec/create_spec.rb
+++ b/examples/ruby_block/spec/create_spec.rb
@@ -1,7 +1,7 @@
 require 'chefspec'
 
 describe 'ruby_block::create' do
-  let(:chef_run) { ChefSpec::SoloRunner.converge(described_recipe) }
+  let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '16.04').converge(described_recipe) }
 
   it 'creates a ruby_block with an explicit action' do
     expect(chef_run).to create_ruby_block('explicit_action')

--- a/examples/ruby_block/spec/run_spec.rb
+++ b/examples/ruby_block/spec/run_spec.rb
@@ -1,7 +1,7 @@
 require 'chefspec'
 
 describe 'ruby_block::run' do
-  let(:chef_run) { ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '16.04').converge(described_recipe) }
+  let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '16.04').converge(described_recipe) }
 
   it 'runs a ruby_block with the default action' do
     expect(chef_run).to run_ruby_block('default_action')

--- a/examples/script/recipes/run_bash.rb
+++ b/examples/script/recipes/run_bash.rb
@@ -7,7 +7,3 @@ end
 bash 'with_attributes' do
   creates 'creates'
 end
-
-bash 'specifying the identity attribute' do
-  command 'identity_attribute'
-end

--- a/examples/script/recipes/run_csh.rb
+++ b/examples/script/recipes/run_csh.rb
@@ -7,7 +7,3 @@ end
 csh 'with_attributes' do
   creates 'creates'
 end
-
-csh 'specifying the identity attribute' do
-  command 'identity_attribute'
-end

--- a/examples/script/recipes/run_ksh.rb
+++ b/examples/script/recipes/run_ksh.rb
@@ -7,7 +7,3 @@ end
 ksh 'with_attributes' do
   creates 'creates'
 end
-
-ksh 'specifying the identity attribute' do
-  command 'identity_attribute'
-end

--- a/examples/script/recipes/run_perl.rb
+++ b/examples/script/recipes/run_perl.rb
@@ -7,7 +7,3 @@ end
 perl 'with_attributes' do
   creates 'creates'
 end
-
-perl 'specifying the identity attribute' do
-  command 'identity_attribute'
-end

--- a/examples/script/recipes/run_python.rb
+++ b/examples/script/recipes/run_python.rb
@@ -7,7 +7,3 @@ end
 python 'with_attributes' do
   creates 'creates'
 end
-
-python 'specifying the identity attribute' do
-  command 'identity_attribute'
-end

--- a/examples/script/recipes/run_ruby.rb
+++ b/examples/script/recipes/run_ruby.rb
@@ -7,7 +7,3 @@ end
 ruby 'with_attributes' do
   creates 'creates'
 end
-
-ruby 'specifying the identity attribute' do
-  command 'identity_attribute'
-end

--- a/examples/script/recipes/run_script.rb
+++ b/examples/script/recipes/run_script.rb
@@ -7,7 +7,3 @@ end
 script 'with_attributes' do
   creates 'creates'
 end
-
-script 'specifying the identity attribute' do
-  command 'identity_attribute'
-end

--- a/examples/script/spec/run_bash_spec.rb
+++ b/examples/script/spec/run_bash_spec.rb
@@ -16,8 +16,4 @@ describe 'script::run_bash' do
     expect(chef_run).to run_bash('with_attributes').with(creates: 'creates')
     expect(chef_run).to_not run_bash('with_attributes').with(creates: 'bacon')
   end
-
-  it 'runs a bash script when specifying the identity attribute' do
-    expect(chef_run).to run_bash('identity_attribute')
-  end
 end

--- a/examples/script/spec/run_csh_spec.rb
+++ b/examples/script/spec/run_csh_spec.rb
@@ -16,8 +16,4 @@ describe 'script::run_csh' do
     expect(chef_run).to run_csh('with_attributes').with(creates: 'creates')
     expect(chef_run).to_not run_csh('with_attributes').with(creates: 'bacon')
   end
-
-  it 'runs a csh script when specifying the identity attribute' do
-    expect(chef_run).to run_csh('identity_attribute')
-  end
 end

--- a/examples/script/spec/run_ksh_spec.rb
+++ b/examples/script/spec/run_ksh_spec.rb
@@ -1,7 +1,7 @@
 require 'chefspec'
 
 describe 'script::run_ksh' do
-  let(:chef_run) { ChefSpec::SoloRunner.converge(described_recipe) }
+  let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '16.04').converge(described_recipe) }
 
   it 'runs a ksh script with the default action' do
     expect(chef_run).to run_ksh('default_action')
@@ -15,9 +15,5 @@ describe 'script::run_ksh' do
   it 'runs a ksh script with attributes' do
     expect(chef_run).to run_ksh('with_attributes').with(creates: 'creates')
     expect(chef_run).to_not run_ksh('with_attributes').with(creates: 'bacon')
-  end
-
-  it 'runs a ksh script when specifying the identity attribute' do
-    expect(chef_run).to run_ksh('identity_attribute')
   end
 end

--- a/examples/script/spec/run_perl_spec.rb
+++ b/examples/script/spec/run_perl_spec.rb
@@ -16,8 +16,4 @@ describe 'script::run_perl' do
     expect(chef_run).to run_perl('with_attributes').with(creates: 'creates')
     expect(chef_run).to_not run_perl('with_attributes').with(creates: 'bacon')
   end
-
-  it 'runs a perl script when specifying the identity attribute' do
-    expect(chef_run).to run_perl('identity_attribute')
-  end
 end

--- a/examples/script/spec/run_python_spec.rb
+++ b/examples/script/spec/run_python_spec.rb
@@ -16,8 +16,4 @@ describe 'script::run_python' do
     expect(chef_run).to run_python('with_attributes').with(creates: 'creates')
     expect(chef_run).to_not run_python('with_attributes').with(creates: 'bacon')
   end
-
-  it 'runs a python script when specifying the identity attribute' do
-    expect(chef_run).to run_python('identity_attribute')
-  end
 end

--- a/examples/script/spec/run_ruby_spec.rb
+++ b/examples/script/spec/run_ruby_spec.rb
@@ -16,8 +16,4 @@ describe 'script::run_ruby' do
     expect(chef_run).to run_ruby('with_attributes').with(creates: 'creates')
     expect(chef_run).to_not run_ruby('with_attributes').with(creates: 'bacon')
   end
-
-  it 'runs a ruby script when specifying the identity attribute' do
-    expect(chef_run).to run_ruby('identity_attribute')
-  end
 end

--- a/examples/script/spec/run_script_spec.rb
+++ b/examples/script/spec/run_script_spec.rb
@@ -16,8 +16,4 @@ describe 'script::run_script' do
     expect(chef_run).to run_script('with_attributes').with(creates: 'creates')
     expect(chef_run).to_not run_script('with_attributes').with(creates: 'bacon')
   end
-
-  it 'runs a script when specifying the identity attribute' do
-    expect(chef_run).to run_script('identity_attribute')
-  end
 end

--- a/examples/server/spec/data_bag_spec.rb
+++ b/examples/server/spec/data_bag_spec.rb
@@ -3,14 +3,14 @@ require 'chefspec'
 describe 'server::data_bag' do
   let(:chef_run) do
     ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '16.04') do |_node, server|
-      server.create_data_bag('accounts',                                'github' => {
-                               'username' => 'sethvargo',
-                               'password' => 'p@ssW0rd!',
-                             },
-                                                                        'twitter' => {
-                                                                          'username' => 'sethvargo',
-                                                                          'password' => '0th3r',
-                                                                        })
+      server.create_data_bag('accounts', 'github' => {
+                                             'username' => 'sethvargo',
+                                             'password' => 'p@ssW0rd!',
+                                          },
+                                          'twitter' => {
+                                            'username' => 'sethvargo',
+                                            'password' => '0th3r',
+                                          })
     end.converge(described_recipe)
   end
 

--- a/examples/server/spec/node_spec.rb
+++ b/examples/server/spec/node_spec.rb
@@ -27,7 +27,7 @@ describe 'server::node' do
 
       node = chef_run.get_node('chefspec')
       expect(node['kernel']['name']).to eq('Linux')
-      expect(node['kernel']['release']).to eq('4.4.0-21-generic')
+      expect(node['kernel']['release']).to match(/4.4.0-.*-generic/) # avoid failing when fauxhai data changes
       expect(node['kernel']['machine']).to eq('x86_64')
     end
   end

--- a/examples/solaris_package/spec/upgrade_spec.rb
+++ b/examples/solaris_package/spec/upgrade_spec.rb
@@ -1,7 +1,10 @@
 require 'chefspec'
 
 describe 'solaris_package::upgrade' do
-  let(:chef_run) { ChefSpec::SoloRunner.converge(described_recipe) }
+  let(:chef_run) do
+    ChefSpec::ServerRunner.new(platform: 'solaris2', version: '5.11')
+                          .converge(described_recipe)
+  end
 
   it 'upgrades a solaris_package with an explicit action' do
     expect(chef_run).to upgrade_solaris_package('explicit_action')

--- a/examples/stub_data_bag/spec/default_spec.rb
+++ b/examples/stub_data_bag/spec/default_spec.rb
@@ -1,7 +1,7 @@
 require 'chefspec'
 
 describe 'stub_data_bag::default' do
-  let(:chef_run) { ChefSpec::SoloRunner.converge(described_recipe) }
+  let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '16.04').converge(described_recipe) }
 
   context 'when the data_bag is not stubbed' do
     it 'raises an exception' do

--- a/examples/stub_data_bag_item/spec/default_spec.rb
+++ b/examples/stub_data_bag_item/spec/default_spec.rb
@@ -1,7 +1,7 @@
 require 'chefspec'
 
 describe 'stub_data_bag_item::default' do
-  let(:chef_run) { ChefSpec::SoloRunner.converge(described_recipe) }
+  let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '16.04').converge(described_recipe) } 
 
   context 'when the data_bag_item is not stubbed' do
     it 'raises an exception' do

--- a/examples/stub_search/spec/default_spec.rb
+++ b/examples/stub_search/spec/default_spec.rb
@@ -1,7 +1,7 @@
 require 'chefspec'
 
 describe 'stub_search::default' do
-  let(:chef_run) { ChefSpec::SoloRunner.converge(described_recipe) }
+  let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '16.04').converge(described_recipe) }
 
   context 'when the search is not stubbed' do
     it 'raises an exception' do

--- a/examples/yum_package/spec/install_spec.rb
+++ b/examples/yum_package/spec/install_spec.rb
@@ -2,7 +2,7 @@ require 'chefspec'
 
 describe 'yum_package::install' do
   let(:chef_run) do
-    ChefSpec::ServerRunner.new(platform: 'centos', version: '7.2.1511')
+    ChefSpec::ServerRunner.new(platform: 'centos', version: '7.3.1611')
                           .converge(described_recipe)
   end
 

--- a/examples/yum_package/spec/purge_spec.rb
+++ b/examples/yum_package/spec/purge_spec.rb
@@ -2,7 +2,7 @@ require 'chefspec'
 
 describe 'yum_package::purge' do
   let(:chef_run) do
-    ChefSpec::ServerRunner.new(platform: 'centos', version: '7.2.1511')
+    ChefSpec::ServerRunner.new(platform: 'centos', version: '7.3.1611')
                           .converge(described_recipe)
   end
 

--- a/examples/yum_package/spec/remove_spec.rb
+++ b/examples/yum_package/spec/remove_spec.rb
@@ -2,7 +2,7 @@ require 'chefspec'
 
 describe 'yum_package::remove' do
   let(:chef_run) do
-    ChefSpec::ServerRunner.new(platform: 'centos', version: '7.2.1511')
+    ChefSpec::ServerRunner.new(platform: 'centos', version: '7.3.1611')
                           .converge(described_recipe)
   end
 

--- a/examples/yum_package/spec/upgrade_spec.rb
+++ b/examples/yum_package/spec/upgrade_spec.rb
@@ -2,7 +2,7 @@ require 'chefspec'
 
 describe 'yum_package::upgrade' do
   let(:chef_run) do
-    ChefSpec::ServerRunner.new(platform: 'centos', version: '7.2.1511')
+    ChefSpec::ServerRunner.new(platform: 'centos', version: '7.3.1611')
                           .converge(described_recipe)
   end
 

--- a/examples/yum_repository/spec/add_spec.rb
+++ b/examples/yum_repository/spec/add_spec.rb
@@ -2,7 +2,7 @@ require 'chefspec'
 
 describe 'yum_repository::add' do
   let(:chef_run) do
-    ChefSpec::ServerRunner.new(platform: 'centos', version: '7.2.1511')
+    ChefSpec::ServerRunner.new(platform: 'centos', version: '7.3.1611')
                           .converge(described_recipe)
   end
 

--- a/examples/yum_repository/spec/create_spec.rb
+++ b/examples/yum_repository/spec/create_spec.rb
@@ -2,7 +2,7 @@ require 'chefspec'
 
 describe 'yum_repository::create' do
   let(:chef_run) do
-    ChefSpec::ServerRunner.new(platform: 'centos', version: '7.2.1511')
+    ChefSpec::ServerRunner.new(platform: 'centos', version: '7.3.1611')
                           .converge(described_recipe)
   end
 

--- a/examples/yum_repository/spec/delete_spec.rb
+++ b/examples/yum_repository/spec/delete_spec.rb
@@ -2,7 +2,7 @@ require 'chefspec'
 
 describe 'yum_repository::delete' do
   let(:chef_run) do
-    ChefSpec::ServerRunner.new(platform: 'centos', version: '7.2.1511')
+    ChefSpec::ServerRunner.new(platform: 'centos', version: '7.3.1611')
                           .converge(described_recipe)
   end
 

--- a/examples/yum_repository/spec/makecache_spec.rb
+++ b/examples/yum_repository/spec/makecache_spec.rb
@@ -2,7 +2,7 @@ require 'chefspec'
 
 describe 'yum_repository::makecache' do
   let(:chef_run) do
-    ChefSpec::ServerRunner.new(platform: 'centos', version: '7.2.1511')
+    ChefSpec::ServerRunner.new(platform: 'centos', version: '7.3.1611')
                           .converge(described_recipe)
   end
 

--- a/examples/yum_repository/spec/remove_spec.rb
+++ b/examples/yum_repository/spec/remove_spec.rb
@@ -2,7 +2,7 @@ require 'chefspec'
 
 describe 'yum_repository::remove' do
   let(:chef_run) do
-    ChefSpec::ServerRunner.new(platform: 'centos', version: '7.2.1511')
+    ChefSpec::ServerRunner.new(platform: 'centos', version: '7.3.1611')
                           .converge(described_recipe)
   end
 

--- a/examples/zypper_package/spec/install_spec.rb
+++ b/examples/zypper_package/spec/install_spec.rb
@@ -1,7 +1,7 @@
 require 'chefspec'
 
 describe 'zypper_package::install' do
-  let(:chef_run) { ChefSpec::SoloRunner.converge(described_recipe) }
+  let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'opensuse', version: '42.1').converge(described_recipe) }
 
   it 'installs a zypper_package with the default action' do
     expect(chef_run).to install_zypper_package('default_action')

--- a/examples/zypper_package/spec/purge_spec.rb
+++ b/examples/zypper_package/spec/purge_spec.rb
@@ -1,7 +1,7 @@
 require 'chefspec'
 
 describe 'zypper_package::purge' do
-  let(:chef_run) { ChefSpec::SoloRunner.converge(described_recipe) }
+  let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'opensuse', version: '42.1').converge(described_recipe) }
 
   it 'purges a zypper_package with an explicit action' do
     expect(chef_run).to purge_zypper_package('explicit_action')

--- a/examples/zypper_package/spec/remove_spec.rb
+++ b/examples/zypper_package/spec/remove_spec.rb
@@ -1,7 +1,7 @@
 require 'chefspec'
 
 describe 'zypper_package::remove' do
-  let(:chef_run) { ChefSpec::SoloRunner.converge(described_recipe) }
+  let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'opensuse', version: '42.1').converge(described_recipe) }
 
   it 'removes a zypper_package with an explicit action' do
     expect(chef_run).to remove_zypper_package('explicit_action')

--- a/examples/zypper_package/spec/upgrade_spec.rb
+++ b/examples/zypper_package/spec/upgrade_spec.rb
@@ -1,7 +1,7 @@
 require 'chefspec'
 
 describe 'zypper_package::upgrade' do
-  let(:chef_run) { ChefSpec::SoloRunner.converge(described_recipe) }
+  let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'opensuse', version: '42.1').converge(described_recipe) }
 
   it 'upgrades a zypper_package with an explicit action' do
     expect(chef_run).to upgrade_zypper_package('explicit_action')

--- a/lib/chefspec/macros.rb
+++ b/lib/chefspec/macros.rb
@@ -139,7 +139,7 @@ module ChefSpec
     #   stub_node('mynode.example')
     #
     # @example mocking a specific platform and version
-    #   stub_node('mynode.example', platform: 'ubuntu', version: '12.04')
+    #   stub_node('mynode.example', platform: 'ubuntu', version: '16.04')
     #
     # @example overriding a specific ohai attribute
     #   stub_node('mynode.example', ohai: { ipaddress: '1.2.3.4' })

--- a/lib/chefspec/server_methods.rb
+++ b/lib/chefspec/server_methods.rb
@@ -115,7 +115,7 @@ module ChefSpec
     #
     # @example Create a node from a +Chef::Node+ object
     #
-    #   node = stub_node('bacon', platform: 'ubuntu', version: '12.04')
+    #   node = stub_node('bacon', platform: 'ubuntu', version: '16.04')
     #   create_node(node)
     #
     # @param [String, Chef::Node] object

--- a/lib/chefspec/solo_runner.rb
+++ b/lib/chefspec/solo_runner.rb
@@ -34,7 +34,7 @@ module ChefSpec
     #   ChefSpec::SoloRunner.new
     #
     # @example Specifying the platform and version
-    #   ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '12.04')
+    #   ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '16.04')
     #
     # @example Specifying the cookbook path
     #   ChefSpec::SoloRunner.new(cookbook_path: ['/cookbooks'])

--- a/spec/unit/macros_spec.rb
+++ b/spec/unit/macros_spec.rb
@@ -71,8 +71,8 @@ describe ChefSpec::Macros do
     end
 
     it 'sets the automatic attributes for a specific platform and version' do
-      node = described_class.stub_node('node.example', platform: 'ubuntu', version: '12.04')
-      expect(node.automatic).to eq(Fauxhai.mock(platform: 'ubuntu', version: '12.04').data)
+      node = described_class.stub_node('node.example', platform: 'ubuntu', version: '16.04')
+      expect(node.automatic).to eq(Fauxhai.mock(platform: 'ubuntu', version: '16.04').data)
     end
 
     it 'sets the automatic attributes from a JSON data path' do

--- a/spec/unit/solo_runner_spec.rb
+++ b/spec/unit/solo_runner_spec.rb
@@ -93,12 +93,12 @@ describe ChefSpec::SoloRunner do
     end
 
     context 'fauxhai attributes' do
-      let(:hash) { described_class.new(platform: 'ubuntu', version: '12.04').node.to_hash }
+      let(:hash) { described_class.new(platform: 'ubuntu', version: '16.04').node.to_hash }
 
       it 'sets the attributes from fauxhai' do
         expect(hash['os']).to eq('linux')
         expect(hash['languages']['ruby']['ruby_bin']).to eq('/usr/local/bin/ruby')
-        expect(hash['os_version']).to eq('3.2.0-92-generic')
+        expect(hash['os_version']).to match(/4.4.0-.*-generic/) # avoid failing when fauxhai data changes
         expect(hash['fqdn']).to eq('fauxhai.local')
         expect(hash['domain']).to eq('local')
         expect(hash['ipaddress']).to eq('10.0.0.2')


### PR DESCRIPTION
Update specs to more recent platforms
Avoid chef deprecation warnings in script resources
Avoid fauxhai deprecation warnings when we don't specify a platform