### PR TITLE
Release 6.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG for ChefSpec
 
+## 6.1.0 (March 9, 2017)
+
+- Loosen the Fauxhai dependency to allow Fauxhai 4.0 This deprecates a large number of Ohai mocks for end of life platforms. See <https://github.com/customink/fauxhai/blob/master/PLATFORMS.md> for the current list of platforms supported by Fauxhai
+- SoloRunner defaults to use_policyfile == false now
+
 ## 6.0.1 (February 24, 2017)
 
 - Add the ability to set the Chef Zero port range used by the ServerRunner

--- a/chefspec.gemspec
+++ b/chefspec.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.2'
 
   s.add_dependency 'chef',    '>= 12.0'
-  s.add_dependency 'fauxhai', '~> 3.6'
+  s.add_dependency 'fauxhai', '>= 3.6', '< 5'
   s.add_dependency 'rspec',   '~> 3.0'
 
   # Development Dependencies

--- a/lib/chefspec/version.rb
+++ b/lib/chefspec/version.rb
@@ -1,3 +1,3 @@
 module ChefSpec
-  VERSION = '6.0.1'
+  VERSION = '6.1.0'
 end


### PR DESCRIPTION
Release 6.1.0 so we can pull in the latest Fauxhai data