### PR TITLE
Correcly handle the block form of search() when using stubs

### DIFF
--- a/examples/stub_search/recipes/block.rb
+++ b/examples/stub_search/recipes/block.rb
@@ -1,0 +1,3 @@
+hosts = []
+search(:node, 'roles:web') {|n| hosts << n['name'] }
+raise 'test failure' unless hosts.length == 1 && hosts[0] == 'example.com'

--- a/examples/stub_search/recipes/default.rb
+++ b/examples/stub_search/recipes/default.rb
@@ -1,5 +1,2 @@
-template '/tmp/specific_stub' do
-  variables(
-    nodes: search(:node, 'name:example.com')
-  )
-end
+hosts = search(:node, 'name:example.com')
+raise 'test failure' unless hosts.length == 1 && hosts[0]['name'] == 'example.com'

--- a/examples/stub_search/spec/block_spec.rb
+++ b/examples/stub_search/spec/block_spec.rb
@@ -1,0 +1,27 @@
+require 'chefspec'
+
+describe 'stub_search::block' do
+  let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '16.04').converge(described_recipe) }
+
+  context 'when the search is not stubbed' do
+    it 'raises an exception' do
+      expect do
+        chef_run
+      end.to raise_error(ChefSpec::Error::SearchNotStubbed)
+    end
+  end
+
+  context 'as a String' do
+    it 'does not raise an exception' do
+      stub_search(:node, 'roles:web').and_return([{ name: 'example.com' }])
+      expect { chef_run }.to_not raise_error
+    end
+  end
+
+  context 'as a Regexp' do
+    it 'does not raise an exception' do
+      stub_search(:node, /roles:(.+)/).and_return([{ name: 'example.com' }])
+      expect { chef_run }.to_not raise_error
+    end
+  end
+end

--- a/features/stub_search.feature
+++ b/features/stub_search.feature
@@ -3,5 +3,5 @@ Feature: The stub_search matcher
     * I am using the "stub_search" cookbook
 
   Scenario: Running specs
-    * I successfully run `rspec spec/default_spec.rb`
+    * I successfully run `rspec spec/default_spec.rb spec/block_spec.rb`
     * the output should contain "0 failures"

--- a/lib/chefspec/extensions/chef/data_query.rb
+++ b/lib/chefspec/extensions/chef/data_query.rb
@@ -14,7 +14,12 @@ module Chef::DSL::DataQuery
       raise ChefSpec::Error::SearchNotStubbed.new(args: [type, query])
     end
 
-    stub.result
+    if block
+      Array(stub.result).each {|r| block.call(r) }
+      true
+    else
+      stub.result
+    end
   end
 
   # @see Chef::DSL::DataQuery#data_bag


### PR DESCRIPTION
The true response matches what Chef does, though it's kind of odd.

Probably needs tests or something but I'm free-handing this.