### PR TITLE
fix use_inline_resources for Chef 13

### DIFF
--- a/lib/chefspec/extensions/chef/lwrp_base.rb
+++ b/lib/chefspec/extensions/chef/lwrp_base.rb
@@ -1,8 +1,13 @@
-if defined?(Chef::Provider::LWRPBase::InlineResources) # < 12.5
+# XXX: This monkeypatch is somewhat terrible and dumps all of the
+# resources in the sub-resource collection into the main resource
+# collection.  Chefspec needs to be taught how to deal with
+# sub-resource collections.
+
+if defined?(Chef::Provider::LWRPBase::InlineResources)
   class Chef
     class Provider
       class LWRPBase < Provider
-        module InlineResources
+        module InlineResources # < 12.5
           module ClassMethods
             def action(name, &block)
               define_method("action_#{name}", &block)
@@ -10,12 +15,7 @@ if defined?(Chef::Provider::LWRPBase::InlineResources) # < 12.5
           end
         end
       end
-    end
-  end
-elsif defined?(Chef::Provider::InlineResources) # ~> 12.5
-  class Chef
-    class Provider
-      module InlineResources
+      module InlineResources # ~> 12.5
         def initialize(resource, run_context)
           super
           @run_context = run_context

--- a/lib/chefspec/extensions/chef/lwrp_base.rb
+++ b/lib/chefspec/extensions/chef/lwrp_base.rb
@@ -1,45 +1,40 @@
-# Override Chef LWRP creation to remove existing class to avoid redefinition warnings.
-class Chef
-  class Provider
-    class LWRPBase < Provider
-      # 12.4 version of inline resources
+if defined?(Chef::Provider::LWRPBase::InlineResources) # < 12.5
+  class Chef
+    class Provider
+      class LWRPBase < Provider
+        module InlineResources
+          module ClassMethods
+            def action(name, &block)
+              define_method("action_#{name}", &block)
+            end
+          end
+        end
+      end
+    end
+  end
+elsif defined?(Chef::Provider::InlineResources) # ~> 12.5
+  class Chef
+    class Provider
       module InlineResources
+        def initialize(resource, run_context)
+          super
+          @run_context = run_context
+          @resource_collection = run_context.resource_collection
+        end
+
         module ClassMethods
-          #
-          # For LWRPs that call +use_inline_resources+, do not create another
-          # +resource_collection+ so that everything is added to the parent
-          # +resource_collection+.
-          #
-          # @param [String] name
-          #
-          # @override Chef::Provider::LWRPBase::InlineResources::ClassMethods#action
-          #
           def action(name, &block)
             define_method("action_#{name}", &block)
           end
         end
       end
     end
-
-    # 12.5 version of inline resources
-    module InlineResources
-      #
-      # For LWRPs that call +use_inline_resources+, do not create another
-      # +resource_collection+ so that everything is added to the parent
-      # +resource_collection+.
-      #
-      # @param [String] name
-      #
-      def initialize(resource, run_context)
-        super
-        @run_context = run_context
-        @resource_collection = run_context.resource_collection
-      end
-
-      module ClassMethods
-        def action(name, &block)
-          define_method("action_#{name}", &block)
-        end
+  end
+else # >= 13.0
+  class Chef
+    class Provider
+      def self.action(name, &block)
+        define_method("action_#{name}", &block)
       end
     end
   end


### PR DESCRIPTION
this is still the same kinda broken approach which just breaks
use_inline_resources encapsulation entirely, but chefspec has
been doing this since chef-11 times.

closes #827

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>