### PR TITLE
fixes for chef-13 removal of resource cloning

### DIFF
--- a/examples/multiple_actions/recipes/reversed.rb
+++ b/examples/multiple_actions/recipes/reversed.rb
@@ -1,0 +1,9 @@
+service 'foo' do
+  stop_command 'bar'
+  action :stop
+end
+
+service 'foo' do
+  start_command 'baz'
+  action :start
+end

--- a/examples/multiple_actions/recipes/sequential.rb
+++ b/examples/multiple_actions/recipes/sequential.rb
@@ -1,7 +1,9 @@
-service 'resource' do
+service 'foo' do
+  start_command 'baz'
   action :start
 end
 
-service 'resource' do
-  action :nothing
+service 'foo' do
+  stop_command 'bar'
+  action :stop
 end

--- a/examples/multiple_actions/spec/reversed_spec.rb
+++ b/examples/multiple_actions/spec/reversed_spec.rb
@@ -1,6 +1,6 @@
 require 'chefspec'
 
-describe 'multiple_actions::sequential' do
+describe 'multiple_actions::reversed' do
   let(:chef_run) do
     ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '16.04', log_level: :fatal)
                           .converge(described_recipe)

--- a/features/multiple_actions.feature
+++ b/features/multiple_actions.feature
@@ -9,3 +9,4 @@ Feature: The multiple_actions matcher
     | Matcher    |
     | default    |
     | sequential |
+    | reversed   |

--- a/lib/chefspec/matchers/resource_matcher.rb
+++ b/lib/chefspec/matchers/resource_matcher.rb
@@ -39,7 +39,7 @@ module ChefSpec::Matchers
     end
 
     def description
-      %Q{#{@expected_action} #{@resource_name} "#{@expected_identity}"}
+      %Q{#{@expected_actioe} #{@resource_name} "#{@expected_identity}"}
     end
 
     def matches?(runner)
@@ -47,42 +47,35 @@ module ChefSpec::Matchers
 
       if resource
         ChefSpec::Coverage.cover!(resource)
-        resource.performed_action?(@expected_action) && unmatched_parameters.empty? && correct_phase?
-      else
-        false
+        unmatched_parameters.empty? && correct_phase?
       end
     end
 
     def failure_message
       if resource
-        if resource.performed_action?(@expected_action)
-          if unmatched_parameters.empty?
-            if @compile_time
-              %Q{expected "#{resource.to_s}" to be run at compile time}
-            else
-              %Q{expected "#{resource.to_s}" to be run at converge time}
-            end
+        if unmatched_parameters.empty?
+          if @compile_time
+            %Q{expected "#{resource.to_s}" to be run at compile time}
           else
-            message = %Q{expected "#{resource.to_s}" to have parameters:} \
-            "\n\n" \
-            "  " + unmatched_parameters.collect { |parameter, h|
-              msg = "#{parameter} #{h[:expected].inspect}, was #{h[:actual].inspect}"
-              diff = ::RSpec::Matchers::ExpectedsForMultipleDiffs.from(h[:expected]) \
-                     .message_with_diff(message, ::RSpec::Expectations::differ, h[:actual])
-              msg += diff if diff
-              msg
-            }.join("\n  ")
+            %Q{expected "#{resource.to_s}" to be run at converge time}
           end
         else
-          %Q{expected "#{resource.to_s}" actions #{resource.performed_actions.inspect}} \
-          " to include :#{@expected_action}"
+          message = %Q{expected "#{resource.to_s}" to have parameters:} \
+            "\n\n" \
+            "  " + unmatched_parameters.collect { |parameter, h|
+            msg = "#{parameter} #{h[:expected].inspect}, was #{h[:actual].inspect}"
+            diff = ::RSpec::Matchers::ExpectedsForMultipleDiffs.from(h[:expected]) \
+              .message_with_diff(message, ::RSpec::Expectations::differ, h[:actual])
+            msg += diff if diff
+            msg
+          }.join("\n  ")
         end
       else
         %Q{expected "#{@resource_name}[#{@expected_identity}]"} \
-        " with action :#{@expected_action} to be in Chef run." \
-        " Other #{@resource_name} resources:" \
-        "\n\n" \
-        "  " + similar_resources.map(&:to_s).join("\n  ") + "\n "
+          " with action :#{@expected_action} to be in Chef run." \
+          " Other #{@resource_name} resources:" \
+          "\n\n" \
+          "  " + similar_resources.map(&:to_s).join("\n  ") + "\n "
       end
     end
 
@@ -165,7 +158,7 @@ module ChefSpec::Matchers
     # @return [Chef::Resource, nil]
     #
     def resource
-      @_resource ||= @runner.find_resource(@resource_name, @expected_identity)
+      @_resource ||= @runner.find_resource(@resource_name, @expected_identity, @expected_action)
     end
 
     #


### PR DESCRIPTION
resource cloning was removed in chef-13.

not sure that chefspec was ever doing it right.

still not positive that this is doing it right.  we should really add all the `with` stuff to the search conditions, or thread an array of resources through it all.