### PR TITLE
Allow fauxhai >=4 and < 6

### DIFF
--- a/chefspec.gemspec
+++ b/chefspec.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.2'
 
   s.add_dependency 'chef',    '>= 12.14.89'
-  s.add_dependency 'fauxhai', '>= 3.6', '< 5'
+  s.add_dependency 'fauxhai', '>= 4', '< 6'
   s.add_dependency 'rspec',   '~> 3.0'
 
   # Development Dependencies


### PR DESCRIPTION
Bring in a more recent fauxhai with updated platform definitions and
also allow for the upcoming 5 release which redumps everything for Chef
13

Signed-off-by: Tim Smith <tsmith@chef.io>