### PR TITLE
Better support for matching action :nothing

### DIFF
--- a/examples/nothing_matcher/recipes/default.rb
+++ b/examples/nothing_matcher/recipes/default.rb
@@ -1,0 +1,13 @@
+ruby_block 'yes' do
+  block { }
+end
+
+ruby_block 'no' do
+  action :nothing
+  block { }
+end
+
+ruby_block 'both' do
+  action [:run, :nothing]
+  block { }
+end

--- a/examples/nothing_matcher/spec/default_spec.rb
+++ b/examples/nothing_matcher/spec/default_spec.rb
@@ -1,0 +1,20 @@
+require 'chefspec'
+
+describe 'nothing_matcher::default' do
+  subject(:chef_run) { ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '16.04').converge(described_recipe) }
+
+  context 'a resource with action :run' do
+    it { is_expected.to run_ruby_block('yes') }
+    it { is_expected.to_not nothing_ruby_block('yes') }
+  end
+
+  context 'a resource with action :nothing' do
+    it { is_expected.to_not run_ruby_block('no') }
+    it { is_expected.to nothing_ruby_block('no') }
+  end
+
+  context 'a resource with action [:run, :nothing]' do
+    it { is_expected.to run_ruby_block('both') }
+    it { is_expected.to_not nothing_ruby_block('both') }
+  end
+end

--- a/lib/chefspec/extensions/chef/resource.rb
+++ b/lib/chefspec/extensions/chef/resource.rb
@@ -52,7 +52,11 @@ module ChefSpec::Extensions::Chef::Resource
   end
 
   def performed_action?(action)
-    !!performed_action(action)
+    if action == :nothing
+      performed_actions.empty?
+    else
+      !!performed_action(action)
+    end
   end
 
   def performed_actions


### PR DESCRIPTION
The new auto-matcher already created them for `nothing_*` but they didn't actually work since nothing isn't a real action.