### PR TITLE
Add chef_node helper to core api

### DIFF
--- a/lib/chefspec/api/core.rb
+++ b/lib/chefspec/api/core.rb
@@ -75,6 +75,10 @@ module ChefSpec
       # By default, run the recipe in the base `describe` block.
       let(:chef_run) { chef_runner.converge(described_recipe) }
 
+      # Give a default accessor for stubbing things on the node object
+      # associated with the runner instance.
+      let(:chef_node) { chef_runner.node }
+
       # Helper method for some of the nestable test value methods like
       # {ClassMethods#default_attributes} and {ClassMethods#step_into}.
       #


### PR DESCRIPTION
This will add a new helper method in the rspec context so folks can easily stub/mock things off of the node object. For example:

```ruby
  before do
    allow(chef_node).to recieve(:abc)
  end
```