### PR TITLE
move shellout to its own module

### DIFF
--- a/lib/chefspec/errors.rb
+++ b/lib/chefspec/errors.rb
@@ -34,6 +34,8 @@ module ChefSpec
     class DataBagNotStubbed < NotStubbed; end
     class DataBagItemNotStubbed < NotStubbed; end
     class ShellOutNotStubbed < ChefSpecError; end
+    class MixlibShellOutNotStubbed < ChefSpecError; end
+    class MixinShellOutNotStubbed < ChefSpecError; end
 
     class CookbookPathNotFound < ChefSpecError; end
     class GemLoadError < ChefSpecError; end

--- a/lib/chefspec/errors.rb
+++ b/lib/chefspec/errors.rb
@@ -34,7 +34,6 @@ module ChefSpec
     class DataBagNotStubbed < NotStubbed; end
     class DataBagItemNotStubbed < NotStubbed; end
     class ShellOutNotStubbed < ChefSpecError; end
-    class MixlibShellOutNotStubbed < ChefSpecError; end
     class MixinShellOutNotStubbed < ChefSpecError; end
 
     class CookbookPathNotFound < ChefSpecError; end

--- a/lib/chefspec/extensions.rb
+++ b/lib/chefspec/extensions.rb
@@ -8,6 +8,7 @@ end
 # STOP! DO NOT ALPHABETIZE!
 require_relative "extensions/chef/data_query" # must be before Chef::Resource loads
 require_relative "extensions/chef/resource"  # must come before client extensions or anything that winds up loading resources
+require_relative "extensions/chef/shell_out"  # must come before client extensions or anything that winds up loading resources
 require_relative "extensions/chef/provider"
 require_relative "extensions/chef/securable"
 require_relative "extensions/chef/client"

--- a/lib/chefspec/extensions.rb
+++ b/lib/chefspec/extensions.rb
@@ -7,8 +7,8 @@ end
 
 # STOP! DO NOT ALPHABETIZE!
 require_relative "extensions/chef/data_query" # must be before Chef::Resource loads
-require_relative "extensions/chef/resource"  # must come before client extensions or anything that winds up loading resources
 require_relative "extensions/chef/shell_out"  # must come before client extensions or anything that winds up loading resources
+require_relative "extensions/chef/resource"  # must come before client extensions or anything that winds up loading resources
 require_relative "extensions/chef/provider"
 require_relative "extensions/chef/securable"
 require_relative "extensions/chef/client"

--- a/lib/chefspec/extensions/chef/resource.rb
+++ b/lib/chefspec/extensions/chef/resource.rb
@@ -64,29 +64,6 @@ module ChefSpec::Extensions::Chef::Resource
   end
 
   #
-  # Defang shell_out and friends so it can never run.
-  #
-  if ChefSpec::API::StubsFor::HAS_SHELLOUT_COMPACTED.satisfied_by?(Gem::Version.create(Chef::VERSION))
-    def shell_out_compacted(*args)
-      return super unless $CHEFSPEC_MODE
-
-      raise ChefSpec::Error::ShellOutNotStubbed.new(args: args, type: "resource", resource: self)
-    end
-
-    def shell_out_compacted!(*args)
-      return super unless $CHEFSPEC_MODE
-
-      shell_out_compacted(*args).tap(&:error!)
-    end
-  else
-    def shell_out(*args)
-      return super unless $CHEFSPEC_MODE
-
-      raise ChefSpec::Error::ShellOutNotStubbed.new(args: args, type: "resource", resource: self)
-    end
-  end
-
-  #
   # tracking
   #
 

--- a/lib/chefspec/extensions/chef/shell_out.rb
+++ b/lib/chefspec/extensions/chef/shell_out.rb
@@ -1,0 +1,32 @@
+require "chef/mixin/shell_out"
+require "chef/version"
+require_relative "../../api/stubs_for"
+require_relative "../../errors"
+
+module ChefSpec::Extensions::Chef::ShellOut
+  #
+  # Defang shell_out and friends so it can never run.
+  #
+  if ChefSpec::API::StubsFor::HAS_SHELLOUT_COMPACTED.satisfied_by?(Gem::Version.create(Chef::VERSION))
+    def shell_out_compacted(*args)
+      return super unless $CHEFSPEC_MODE
+
+      raise ChefSpec::Error::ShellOutNotStubbed.new(args: args, type: "resource", resource: self)
+    end
+
+    def shell_out_compacted!(*args)
+      return super unless $CHEFSPEC_MODE
+
+      shell_out_compacted(*args).tap(&:error!)
+    end
+  else
+    def shell_out(*args)
+      return super unless $CHEFSPEC_MODE
+
+      raise ChefSpec::Error::ShellOutNotStubbed.new(args: args, type: "resource", resource: self)
+    end
+  end
+end
+
+Chef::Mixin::ShellOut.prepend(ChefSpec::Extensions::Chef::ShellOut)
+Chef::Resource.prepend(ChefSpec::Extensions::Chef::ShellOut)

--- a/lib/chefspec/extensions/chef/shell_out.rb
+++ b/lib/chefspec/extensions/chef/shell_out.rb
@@ -7,7 +7,7 @@ require_relative "../../errors"
 
 puts "being included!"
 
-module ChefSpec::Extensions::Chef::ShellOut
+module ::ChefSpec::Extensions::Chef::ShellOut
   #
   # Defang shell_out and friends so it can never run.
   #
@@ -38,7 +38,7 @@ module ChefSpec::Extensions::Chef::ShellOut
   end
 end
 
-module ChefSpec::Extensions::Chef::MixinShellOut
+module ::ChefSpec::Extensions::Chef::MixinShellOut
   #
   # Defang shell_out and friends so it can never run.
   #
@@ -69,7 +69,7 @@ module ChefSpec::Extensions::Chef::MixinShellOut
   end
 end
 
-module ChefSpec::Extensions::Chef::MixlibShellOut
+module ::ChefSpec::Extensions::Chef::MixlibShellOut
   def run_command(*args)
     raise ChefSpec::Error::MixlibShellOutNotStubbed.new(args: args)
   end

--- a/lib/chefspec/extensions/chef/shell_out.rb
+++ b/lib/chefspec/extensions/chef/shell_out.rb
@@ -9,19 +9,25 @@ module ChefSpec::Extensions::Chef::ShellOut
   #
   if ChefSpec::API::StubsFor::HAS_SHELLOUT_COMPACTED.satisfied_by?(Gem::Version.create(Chef::VERSION))
     def shell_out_compacted(*args)
+      puts "#shell_out_compacted"
       return super unless $CHEFSPEC_MODE
+      puts "made it past return"
 
       raise ChefSpec::Error::ShellOutNotStubbed.new(args: args, type: "resource", resource: self)
     end
 
     def shell_out_compacted!(*args)
+      puts "#shell_out_compacted!"
       return super unless $CHEFSPEC_MODE
+      puts "made it past return"
 
       shell_out_compacted(*args).tap(&:error!)
     end
   else
     def shell_out(*args)
+      puts "#shell_out"
       return super unless $CHEFSPEC_MODE
+      puts "made it past return"
 
       raise ChefSpec::Error::ShellOutNotStubbed.new(args: args, type: "resource", resource: self)
     end

--- a/lib/chefspec/extensions/chef/shell_out.rb
+++ b/lib/chefspec/extensions/chef/shell_out.rb
@@ -69,12 +69,5 @@ module ::ChefSpec::Extensions::Chef::MixinShellOut
   end
 end
 
-module ::ChefSpec::Extensions::Chef::Other
-  def run_command(*args)
-    raise ChefSpec::Error::MixlibShellOutNotStubbed.new(command: self.command, args: args)
-  end
-end
-
-::Mixlib::ShellOut.prepend(::ChefSpec::Extensions::Chef::Other)
 ::Chef::Mixin::ShellOut.prepend(::ChefSpec::Extensions::Chef::MixinShellOut)
 ::Chef::Resource.prepend(::ChefSpec::Extensions::Chef::ResourceShellOut)

--- a/lib/chefspec/extensions/chef/shell_out.rb
+++ b/lib/chefspec/extensions/chef/shell_out.rb
@@ -3,6 +3,8 @@ require "chef/version"
 require_relative "../../api/stubs_for"
 require_relative "../../errors"
 
+puts "being included!"
+
 module ChefSpec::Extensions::Chef::ShellOut
   #
   # Defang shell_out and friends so it can never run.

--- a/lib/chefspec/extensions/chef/shell_out.rb
+++ b/lib/chefspec/extensions/chef/shell_out.rb
@@ -1,11 +1,8 @@
 require "chef/mixin/shell_out"
 require "chef/resource"
-require "mixlib/shellout"
 require "chef/version"
 require_relative "../../api/stubs_for"
 require_relative "../../errors"
-
-puts "being included!"
 
 module ::ChefSpec::Extensions::Chef::ResourceShellOut
   #

--- a/lib/chefspec/extensions/chef/shell_out.rb
+++ b/lib/chefspec/extensions/chef/shell_out.rb
@@ -1,4 +1,5 @@
 require "chef/mixin/shell_out"
+require "chef/resource"
 require "chef/version"
 require_relative "../../api/stubs_for"
 require_relative "../../errors"

--- a/lib/chefspec/extensions/chef/shell_out.rb
+++ b/lib/chefspec/extensions/chef/shell_out.rb
@@ -10,25 +10,19 @@ module ::ChefSpec::Extensions::Chef::ResourceShellOut
   #
   if ChefSpec::API::StubsFor::HAS_SHELLOUT_COMPACTED.satisfied_by?(Gem::Version.create(Chef::VERSION))
     def shell_out_compacted(*args)
-      puts "#shell_out_compacted"
       return super unless $CHEFSPEC_MODE
-      puts "made it past return"
 
       raise ChefSpec::Error::ShellOutNotStubbed.new(args: args, type: "resource", resource: self)
     end
 
     def shell_out_compacted!(*args)
-      puts "#shell_out_compacted!"
       return super unless $CHEFSPEC_MODE
-      puts "made it past return"
 
       shell_out_compacted(*args).tap(&:error!)
     end
   else
     def shell_out(*args)
-      puts "#shell_out"
       return super unless $CHEFSPEC_MODE
-      puts "made it past return"
 
       raise ChefSpec::Error::ShellOutNotStubbed.new(args: args, type: "resource", resource: self)
     end
@@ -41,25 +35,19 @@ module ::ChefSpec::Extensions::Chef::MixinShellOut
   #
   if ChefSpec::API::StubsFor::HAS_SHELLOUT_COMPACTED.satisfied_by?(Gem::Version.create(Chef::VERSION))
     def shell_out_compacted(*args)
-      puts "#shell_out_compacted"
       return super unless $CHEFSPEC_MODE
-      puts "made it past return"
 
       raise ChefSpec::Error::LibraryShellOutNotStubbed.new(args: args, object: self)
     end
 
     def shell_out_compacted!(*args)
-      puts "#shell_out_compacted!"
       return super unless $CHEFSPEC_MODE
-      puts "made it past return"
 
       shell_out_compacted(*args).tap(&:error!)
     end
   else
     def shell_out(*args)
-      puts "#shell_out"
       return super unless $CHEFSPEC_MODE
-      puts "made it past return"
 
       raise ChefSpec::Error::LibraryShellOutNotStubbed.new(args: args, object: self)
     end

--- a/lib/chefspec/extensions/chef/shell_out.rb
+++ b/lib/chefspec/extensions/chef/shell_out.rb
@@ -36,5 +36,13 @@ module ChefSpec::Extensions::Chef::ShellOut
   end
 end
 
-Chef::Mixin::ShellOut.prepend(ChefSpec::Extensions::Chef::ShellOut)
-Chef::Resource.prepend(ChefSpec::Extensions::Chef::ShellOut)
+
+module ChefSpec::Extensions::Chef::ShellOutOther
+  def run_command(*args)
+    raise ChefSpec::Error::ShellOutNotStubbed.new(args: args, type: "resource", resource: self)
+  end
+end
+
+::Mixlib::ShellOut.prepend(ChefSpec::Extensions::Chef::ShellOutOther)
+::Chef::Mixin::ShellOut.prepend(ChefSpec::Extensions::Chef::ShellOut)
+::Chef::Resource.prepend(ChefSpec::Extensions::Chef::ShellOut)

--- a/lib/chefspec/extensions/chef/shell_out.rb
+++ b/lib/chefspec/extensions/chef/shell_out.rb
@@ -69,12 +69,12 @@ module ::ChefSpec::Extensions::Chef::MixinShellOut
   end
 end
 
-module ::ChefSpec::Extensions::Chef::MixlibShellOut
+module ::ChefSpec::Extensions::Chef::Other
   def run_command(*args)
     raise ChefSpec::Error::MixlibShellOutNotStubbed.new(args: args)
   end
 end
 
-::Mixlib::ShellOut.prepend(::ChefSpec::Extensions::Chef::MixlibShellout)
+::Mixlib::ShellOut.prepend(::ChefSpec::Extensions::Chef::Other)
 ::Chef::Mixin::ShellOut.prepend(::ChefSpec::Extensions::Chef::MixinShellOut)
 ::Chef::Resource.prepend(::ChefSpec::Extensions::Chef::ResourceShellOut)

--- a/lib/chefspec/extensions/chef/shell_out.rb
+++ b/lib/chefspec/extensions/chef/shell_out.rb
@@ -1,5 +1,6 @@
 require "chef/mixin/shell_out"
 require "chef/resource"
+require "mixlib/shellout"
 require "chef/version"
 require_relative "../../api/stubs_for"
 require_relative "../../errors"

--- a/lib/chefspec/extensions/chef/shell_out.rb
+++ b/lib/chefspec/extensions/chef/shell_out.rb
@@ -71,7 +71,7 @@ end
 
 module ::ChefSpec::Extensions::Chef::Other
   def run_command(*args)
-    raise ChefSpec::Error::MixlibShellOutNotStubbed.new(args: args)
+    raise ChefSpec::Error::MixlibShellOutNotStubbed.new(command: self.command, args: args)
   end
 end
 

--- a/lib/chefspec/extensions/chef/shell_out.rb
+++ b/lib/chefspec/extensions/chef/shell_out.rb
@@ -7,7 +7,7 @@ require_relative "../../errors"
 
 puts "being included!"
 
-module ::ChefSpec::Extensions::Chef::ShellOut
+module ::ChefSpec::Extensions::Chef::ResourceShellOut
   #
   # Defang shell_out and friends so it can never run.
   #
@@ -64,7 +64,7 @@ module ::ChefSpec::Extensions::Chef::MixinShellOut
       return super unless $CHEFSPEC_MODE
       puts "made it past return"
 
-      raise ChefSpec::Error::ShellOutNotStubbed.new(args: args, object: self)
+      raise ChefSpec::Error::LibraryShellOutNotStubbed.new(args: args, object: self)
     end
   end
 end
@@ -75,6 +75,6 @@ module ::ChefSpec::Extensions::Chef::MixlibShellOut
   end
 end
 
-::Mixlib::ShellOut.prepend(ChefSpec::Extensions::Chef::MixlibShellout)
-::Chef::Mixin::ShellOut.prepend(ChefSpec::Extensions::Chef::MixinShellOut)
-::Chef::Resource.prepend(ChefSpec::Extensions::Chef::ShellOut)
+::Mixlib::ShellOut.prepend(::ChefSpec::Extensions::Chef::MixlibShellout)
+::Chef::Mixin::ShellOut.prepend(::ChefSpec::Extensions::Chef::MixinShellOut)
+::Chef::Resource.prepend(::ChefSpec::Extensions::Chef::ResourceShellOut)

--- a/templates/errors/mixin_shell_out_not_stubbed.erb
+++ b/templates/errors/mixin_shell_out_not_stubbed.erb
@@ -1,0 +1,7 @@
+Executing a real shell_out in <%= @object.class %> is not allowed:
+
+    shell_out(<%= @args.inspect[1..-2] %>)
+
+You can stub this with:
+
+    allow(<%= @object.class %>).to receive(:shell_out).with(<%= @args.inspect[1..-2] %>)

--- a/templates/errors/mixlib_shell_out_not_stubbed.erb
+++ b/templates/errors/mixlib_shell_out_not_stubbed.erb
@@ -1,0 +1,8 @@
+Executing a real Mixlib::ShellOut:
+
+    Mixlib::ShellOut(<%= @args.inspect[1..-2] %>).run_command
+
+You can stub this with:
+
+    so_double = instance_double("Mixlib::ShellOut", run_command: nil, stdout: nil. stderr: nil)
+    allow(Mixlib::ShellOut).to receive(:new).with(<%= @args.inspect[1..-2] %>).and_return(so_double)

--- a/templates/errors/mixlib_shell_out_not_stubbed.erb
+++ b/templates/errors/mixlib_shell_out_not_stubbed.erb
@@ -1,8 +1,8 @@
 Executing a real Mixlib::ShellOut:
 
-    Mixlib::ShellOut(<%= @args.inspect %>).run_command
+    Mixlib::ShellOut(<%= @command.inspect %>).run_command
 
 You can stub this with:
 
     so_double = instance_double("Mixlib::ShellOut", run_command: nil, stdout: nil. stderr: nil)
-    allow(Mixlib::ShellOut).to receive(:new).with(<%= @args.inspect %>).and_return(so_double)
+    allow(Mixlib::ShellOut).to receive(:new).with(<%= @command.inspect %>, any_args).and_return(so_double)

--- a/templates/errors/mixlib_shell_out_not_stubbed.erb
+++ b/templates/errors/mixlib_shell_out_not_stubbed.erb
@@ -1,8 +1,8 @@
 Executing a real Mixlib::ShellOut:
 
-    Mixlib::ShellOut(<%= @args.inspect[1..-2] %>).run_command
+    Mixlib::ShellOut(<%= @args.inspect %>).run_command
 
 You can stub this with:
 
     so_double = instance_double("Mixlib::ShellOut", run_command: nil, stdout: nil. stderr: nil)
-    allow(Mixlib::ShellOut).to receive(:new).with(<%= @args.inspect[1..-2] %>).and_return(so_double)
+    allow(Mixlib::ShellOut).to receive(:new).with(<%= @args.inspect %>).and_return(so_double)

--- a/templates/errors/mixlib_shell_out_not_stubbed.erb
+++ b/templates/errors/mixlib_shell_out_not_stubbed.erb
@@ -1,8 +1,0 @@
-Executing a real Mixlib::ShellOut:
-
-    Mixlib::ShellOut(<%= @command.inspect %>).run_command
-
-You can stub this with:
-
-    so_double = instance_double("Mixlib::ShellOut", run_command: nil, stdout: nil. stderr: nil)
-    allow(Mixlib::ShellOut).to receive(:new).with(<%= @command.inspect %>, any_args).and_return(so_double)


### PR DESCRIPTION
This PR moves the shell_out stub into it's own module so that it can be prepended to both `Chef::Resource` and `Chef::Mixlib::ShellOut`.