### PR TITLE
add support for Chef::Mixin::shellout

### DIFF
--- a/lib/chefspec/errors.rb
+++ b/lib/chefspec/errors.rb
@@ -34,6 +34,7 @@ module ChefSpec
     class DataBagNotStubbed < NotStubbed; end
     class DataBagItemNotStubbed < NotStubbed; end
     class ShellOutNotStubbed < ChefSpecError; end
+    class MixinShellOutNotStubbed < ChefSpecError; end
 
     class CookbookPathNotFound < ChefSpecError; end
     class GemLoadError < ChefSpecError; end

--- a/lib/chefspec/extensions.rb
+++ b/lib/chefspec/extensions.rb
@@ -7,6 +7,7 @@ end
 
 # STOP! DO NOT ALPHABETIZE!
 require_relative "extensions/chef/data_query" # must be before Chef::Resource loads
+require_relative "extensions/chef/shell_out"  # must come before client extensions or anything that winds up loading resources
 require_relative "extensions/chef/resource"  # must come before client extensions or anything that winds up loading resources
 require_relative "extensions/chef/provider"
 require_relative "extensions/chef/securable"

--- a/lib/chefspec/extensions/chef/resource.rb
+++ b/lib/chefspec/extensions/chef/resource.rb
@@ -64,29 +64,6 @@ module ChefSpec::Extensions::Chef::Resource
   end
 
   #
-  # Defang shell_out and friends so it can never run.
-  #
-  if ChefSpec::API::StubsFor::HAS_SHELLOUT_COMPACTED.satisfied_by?(Gem::Version.create(Chef::VERSION))
-    def shell_out_compacted(*args)
-      return super unless $CHEFSPEC_MODE
-
-      raise ChefSpec::Error::ShellOutNotStubbed.new(args: args, type: "resource", resource: self)
-    end
-
-    def shell_out_compacted!(*args)
-      return super unless $CHEFSPEC_MODE
-
-      shell_out_compacted(*args).tap(&:error!)
-    end
-  else
-    def shell_out(*args)
-      return super unless $CHEFSPEC_MODE
-
-      raise ChefSpec::Error::ShellOutNotStubbed.new(args: args, type: "resource", resource: self)
-    end
-  end
-
-  #
   # tracking
   #
 

--- a/lib/chefspec/extensions/chef/shell_out.rb
+++ b/lib/chefspec/extensions/chef/shell_out.rb
@@ -1,0 +1,58 @@
+require "chef/mixin/shell_out"
+require "chef/resource"
+require "chef/version"
+require_relative "../../api/stubs_for"
+require_relative "../../errors"
+
+module ::ChefSpec::Extensions::Chef::ResourceShellOut
+  #
+  # Defang shell_out and friends so it can never run.
+  #
+  if ChefSpec::API::StubsFor::HAS_SHELLOUT_COMPACTED.satisfied_by?(Gem::Version.create(Chef::VERSION))
+    def shell_out_compacted(*args)
+      return super unless $CHEFSPEC_MODE
+
+      raise ChefSpec::Error::ShellOutNotStubbed.new(args: args, type: "resource", resource: self)
+    end
+
+    def shell_out_compacted!(*args)
+      return super unless $CHEFSPEC_MODE
+
+      shell_out_compacted(*args).tap(&:error!)
+    end
+  else
+    def shell_out(*args)
+      return super unless $CHEFSPEC_MODE
+
+      raise ChefSpec::Error::ShellOutNotStubbed.new(args: args, type: "resource", resource: self)
+    end
+  end
+end
+
+module ::ChefSpec::Extensions::Chef::MixinShellOut
+  #
+  # Defang shell_out and friends so it can never run.
+  #
+  if ChefSpec::API::StubsFor::HAS_SHELLOUT_COMPACTED.satisfied_by?(Gem::Version.create(Chef::VERSION))
+    def shell_out_compacted(*args)
+      return super unless $CHEFSPEC_MODE
+
+      raise ChefSpec::Error::LibraryShellOutNotStubbed.new(args: args, object: self)
+    end
+
+    def shell_out_compacted!(*args)
+      return super unless $CHEFSPEC_MODE
+
+      shell_out_compacted(*args).tap(&:error!)
+    end
+  else
+    def shell_out(*args)
+      return super unless $CHEFSPEC_MODE
+
+      raise ChefSpec::Error::LibraryShellOutNotStubbed.new(args: args, object: self)
+    end
+  end
+end
+
+::Chef::Mixin::ShellOut.prepend(::ChefSpec::Extensions::Chef::MixinShellOut)
+::Chef::Resource.prepend(::ChefSpec::Extensions::Chef::ResourceShellOut)

--- a/templates/errors/mixin_shell_out_not_stubbed.erb
+++ b/templates/errors/mixin_shell_out_not_stubbed.erb
@@ -1,0 +1,7 @@
+Executing a real shell_out in <%= @object.class %> is not allowed:
+
+    shell_out(<%= @args.inspect[1..-2] %>)
+
+You can stub this with:
+
+    allow(<%= @object.class %>).to receive(:shell_out).with(<%= @args.inspect[1..-2] %>)


### PR DESCRIPTION
This makes it so when folks include `Chef::Mixin::ShellOut` in their libraries that it's properly catches any unstubbed calls to `#shell_out`.